### PR TITLE
ui: tweak hardcoded dimensions for new LCD display

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -30,7 +30,7 @@ use tide::{Response, Server};
 use evdev::{EventType, InputEventKind, Key};
 
 use embedded_graphics::{
-    mono_font::{ascii::FONT_8X13, MonoTextStyle},
+    mono_font::MonoTextStyle,
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Line, PrimitiveStyle},
@@ -61,6 +61,7 @@ use screensaver_screen::ScreenSaverScreen;
 use system_screen::SystemScreen;
 use uart_screen::UartScreen;
 use usb_screen::UsbScreen;
+use widgets::UI_TEXT_FONT;
 
 pub const LONG_PRESS: Duration = Duration::from_millis(750);
 
@@ -125,31 +126,31 @@ trait MountableScreen: Sync + Send {
     async fn unmount(&mut self);
 }
 
-/// Draw static screen border contining a title and an indicator for the
+/// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
 async fn draw_border(text: &str, screen: Screen, draw_target: &Arc<Mutex<FramebufferDrawTarget>>) {
     let mut draw_target = draw_target.lock().await;
 
     Text::new(
         text,
-        Point::new(4, 13),
-        MonoTextStyle::new(&FONT_8X13, BinaryColor::On),
+        Point::new(8, 17),
+        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
     )
     .draw(&mut *draw_target)
     .unwrap();
 
-    Line::new(Point::new(0, 16), Point::new(118, 16))
+    Line::new(Point::new(0, 24), Point::new(230, 24))
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
         .draw(&mut *draw_target)
         .unwrap();
 
     let screen_idx = screen as i32;
     let num_screens = Screen::ScreenSaver as i32;
-    let x_start = screen_idx * 128 / num_screens;
-    let x_end = (screen_idx + 1) * 128 / num_screens;
+    let x_start = screen_idx * 240 / num_screens;
+    let x_end = (screen_idx + 1) * 240 / num_screens;
 
-    Line::new(Point::new(x_start, 62), Point::new(x_end, 62))
-        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
+    Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
         .draw(&mut *draw_target)
         .unwrap();
 }

--- a/src/ui/dig_out_screen.rs
+++ b/src/ui/dig_out_screen.rs
@@ -63,14 +63,14 @@ impl MountableScreen for DigOutScreen {
             (
                 0,
                 "OUT 0",
-                29,
+                52,
                 &ui.res.dig_io.out_0,
                 &ui.res.adc.out0_volt.topic,
             ),
             (
                 1,
                 "OUT 1",
-                44,
+                72,
                 &ui.res.dig_io.out_1,
                 &ui.res.adc.out1_volt.topic,
             ),
@@ -81,7 +81,7 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -97,7 +97,7 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(54, y - 7),
+                    Point::new(100, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,
@@ -110,9 +110,9 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::bar(
                     voltage.clone(),
                     ui.draw_target.clone(),
-                    Point::new(70, y - 6),
-                    45,
-                    7,
+                    Point::new(130, y - 14),
+                    90,
+                    18,
                     Box::new(|meas: &Measurement| meas.value.abs() / 5.0),
                 )
                 .await,

--- a/src/ui/draw_fb/backend/stub.rs
+++ b/src/ui/draw_fb/backend/stub.rs
@@ -30,7 +30,7 @@ pub struct Framebuffer {
     pub device: (),
     pub var_screen_info: VarScreenInfo,
     pub fix_screen_info: FixScreenInfo,
-    pub frame: [u8; 128 * 64 * 2],
+    pub frame: [u8; 240 * 240 * 2],
 }
 
 impl Framebuffer {
@@ -40,11 +40,11 @@ impl Framebuffer {
             var_screen_info: VarScreenInfo {
                 activate: 0,
                 bits_per_pixel: 16,
-                xres: 128,
-                yres: 64,
+                xres: 240,
+                yres: 240,
             },
-            fix_screen_info: FixScreenInfo { line_length: 256 },
-            frame: [0; 128 * 64 * 2],
+            fix_screen_info: FixScreenInfo { line_length: 480 },
+            frame: [0; 240 * 240 * 2],
         })
     }
 

--- a/src/ui/iobus_screen.rs
+++ b/src/ui/iobus_screen.rs
@@ -61,11 +61,11 @@ impl MountableScreen for IoBusScreen {
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-            Text::new("Power/Fault:", Point::new(0, 26), ui_text_style)
+            Text::new("Power/Fault:", Point::new(8, 52), ui_text_style)
                 .draw(&mut *draw_target)
                 .unwrap();
 
-            Text::new("Scan/CAN OK:", Point::new(0, 40), ui_text_style)
+            Text::new("Scan/CAN OK:", Point::new(8, 72), ui_text_style)
                 .draw(&mut *draw_target)
                 .unwrap();
         }
@@ -78,7 +78,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.dig_io.iobus_pwr_en.clone(),
                 ui.draw_target.clone(),
-                Point::new(80, 26 - 7),
+                Point::new(140, 52 - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
                     false => IndicatorState::Off,
@@ -91,7 +91,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.dig_io.iobus_flt_fb.clone(),
                 ui.draw_target.clone(),
-                Point::new(101, 26 - 7),
+                Point::new(170, 52 - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
                     false => IndicatorState::Off,
@@ -104,7 +104,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.iobus.server_info.clone(),
                 ui.draw_target.clone(),
-                Point::new(80, 40 - 7),
+                Point::new(140, 72 - 10),
                 Box::new(|info: &ServerInfo| match info.lss_state {
                     LSSState::Scanning => IndicatorState::On,
                     LSSState::Idle => IndicatorState::Off,
@@ -117,7 +117,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.iobus.server_info.clone(),
                 ui.draw_target.clone(),
-                Point::new(101, 40 - 7),
+                Point::new(170, 70 - 7),
                 Box::new(|info: &ServerInfo| match info.can_tx_error {
                     false => IndicatorState::On,
                     true => IndicatorState::Off,
@@ -130,7 +130,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::text(
                 ui.res.iobus.nodes.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 54),
+                Point::new(8, 92),
                 Box::new(move |nodes: &Nodes| format!("Nodes: {}", nodes.result.len())),
             )
             .await,

--- a/src/ui/power_screen.rs
+++ b/src/ui/power_screen.rs
@@ -61,7 +61,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.adc.pwr_volt.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 26),
+                Point::new(8, 52),
                 Box::new(|meas: &Measurement| format!("V: {:-6.3}V", meas.value)),
             )
             .await,
@@ -71,9 +71,9 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::bar(
                 ui.res.adc.pwr_volt.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(70, 26 - 6),
-                45,
-                7,
+                Point::new(120, 52 - 14),
+                100,
+                18,
                 Box::new(|meas: &Measurement| meas.value / 48.0),
             )
             .await,
@@ -83,7 +83,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.adc.pwr_curr.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 36),
+                Point::new(8, 72),
                 Box::new(|meas: &Measurement| format!("I: {:-6.3}A", meas.value)),
             )
             .await,
@@ -93,9 +93,9 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::bar(
                 ui.res.adc.pwr_curr.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(70, 36 - 6),
-                45,
-                7,
+                Point::new(120, 72 - 14),
+                100,
+                18,
                 Box::new(|meas: &Measurement| meas.value / 48.0),
             )
             .await,
@@ -105,7 +105,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.dut_pwr.state.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 47),
+                Point::new(8, 92),
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => "On".into(),
                     OutputState::Off => "Off".into(),
@@ -123,7 +123,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::indicator(
                 ui.res.dut_pwr.state.clone(),
                 ui.draw_target.clone(),
-                Point::new(90, 47 - 6),
+                Point::new(120, 92 - 10),
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => IndicatorState::On,
                     OutputState::Off | OutputState::OffFloating => IndicatorState::Off,

--- a/src/ui/rauc_screen.rs
+++ b/src/ui/rauc_screen.rs
@@ -77,7 +77,7 @@ impl MountableScreen for RaucScreen {
             DynamicWidget::text_center(
                 ui.res.dbus.rauc.progress.clone(),
                 ui.draw_target.clone(),
-                Point::new(64, 15),
+                Point::new(120, 100),
                 Box::new(|progress: &Progress| {
                     let (_, text) = progress.message.split_whitespace().fold(
                         (0, String::new()),
@@ -109,9 +109,9 @@ impl MountableScreen for RaucScreen {
             DynamicWidget::bar(
                 ui.res.dbus.rauc.progress.clone(),
                 ui.draw_target.clone(),
-                Point::new(14, 40),
-                100,
-                7,
+                Point::new(20, 180),
+                200,
+                18,
                 Box::new(|progress: &Progress| progress.percentage as f32 / 100.0),
             )
             .await,

--- a/src/ui/reboot_screen.rs
+++ b/src/ui/reboot_screen.rs
@@ -49,7 +49,7 @@ fn rly(draw_target: &mut FramebufferDrawTarget) {
 
     Text::with_alignment(
         "Really reboot?\nLong press to confirm",
-        Point::new(64, 28),
+        Point::new(120, 120),
         text_style,
         Alignment::Center,
     )
@@ -64,7 +64,7 @@ fn brb(draw_target: &mut FramebufferDrawTarget) {
 
     Text::with_alignment(
         "Hold tight\nBe right back",
-        Point::new(64, 28),
+        Point::new(120, 120),
         text_style,
         Alignment::Center,
     )

--- a/src/ui/screensaver_screen.rs
+++ b/src/ui/screensaver_screen.rs
@@ -26,7 +26,7 @@ use async_std::task::{sleep, spawn};
 use async_trait::async_trait;
 
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X9, MonoFont, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoFont, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     text::Text,
@@ -37,7 +37,7 @@ use super::{ButtonEvent, MountableScreen, Screen, Ui};
 
 use crate::broker::{BrokerBuilder, Native, SubscriptionHandle, Topic};
 
-const UI_TEXT_FONT: MonoFont = FONT_6X9;
+const UI_TEXT_FONT: MonoFont = FONT_10X20;
 const SCREEN_TYPE: Screen = Screen::ScreenSaver;
 const SCREENSAVER_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -145,14 +145,11 @@ impl MountableScreen for ScreenSaverScreen {
 
                     let text = Text::new(&hostname, Point::new(0, 0), ui_text_style);
 
-                    let text_dim = text
-                        .bounding_box()
-                        .bottom_right()
-                        .unwrap_or(Point::new(0, 0));
+                    let text_dim = text.bounding_box().size;
 
                     let text = text.translate(Point::new(
-                        bounce(*i, 118 - text_dim.x),
-                        bounce(*i, 64 - text_dim.y) + text_dim.y,
+                        bounce(*i, 230 - (text_dim.width as i32)),
+                        bounce(*i, 240 - (text_dim.height as i32)) + (text_dim.height as i32),
                     ));
 
                     text.draw(target).unwrap();

--- a/src/ui/system_screen.rs
+++ b/src/ui/system_screen.rs
@@ -61,7 +61,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.temperatures.soc_temperature.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 26),
+                Point::new(8, 52),
                 Box::new(|meas: &Measurement| format!("SoC:    {:.0}C", meas.value)),
             )
             .await,
@@ -71,7 +71,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.dbus.network.uplink_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 36),
+                Point::new(8, 72),
                 Box::new(|info: &LinkInfo| match info.carrier {
                     true => format!("Uplink: {}MBit/s", info.speed),
                     false => "Uplink: Down".to_string(),
@@ -84,7 +84,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.dbus.network.dut_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 46),
+                Point::new(8, 92),
                 Box::new(|info: &LinkInfo| match info.carrier {
                     true => format!("DUT:    {}MBit/s", info.speed),
                     false => "DUT:    Down".to_string(),
@@ -97,10 +97,10 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.dbus.network.bridge_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 56),
+                Point::new(8, 112),
                 Box::new(|ips: &Vec<String>| {
                     let ip = ips.get(0).map(|s| s.as_str()).unwrap_or("-");
-                    format!("IP: {}", ip)
+                    format!("IP:     {}", ip)
                 }),
             )
             .await,

--- a/src/ui/uart_screen.rs
+++ b/src/ui/uart_screen.rs
@@ -59,8 +59,8 @@ impl MountableScreen for UartScreen {
         ));
 
         let ports = [
-            (0, "UART RX EN", 29, &ui.res.dig_io.uart_rx_en),
-            (1, "UART TX EN", 44, &ui.res.dig_io.uart_tx_en),
+            (0, "UART RX EN", 52, &ui.res.dig_io.uart_rx_en),
+            (1, "UART TX EN", 72, &ui.res.dig_io.uart_tx_en),
         ];
 
         for (idx, name, y, status) in ports {
@@ -68,7 +68,7 @@ impl MountableScreen for UartScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -84,7 +84,7 @@ impl MountableScreen for UartScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(80, y - 7),
+                    Point::new(160, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,

--- a/src/ui/usb_screen.rs
+++ b/src/ui/usb_screen.rs
@@ -63,21 +63,21 @@ impl MountableScreen for UsbScreen {
             (
                 0,
                 "Port 1",
-                28,
+                52,
                 &ui.res.usb_hub.port1.powered,
                 &ui.res.adc.usb_host1_curr.topic,
             ),
             (
                 1,
                 "Port 2",
-                41,
+                72,
                 &ui.res.usb_hub.port2.powered,
                 &ui.res.adc.usb_host2_curr.topic,
             ),
             (
                 2,
                 "Port 3",
-                54,
+                92,
                 &ui.res.usb_hub.port3.powered,
                 &ui.res.adc.usb_host3_curr.topic,
             ),
@@ -88,7 +88,7 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -104,7 +104,7 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(54, y - 7),
+                    Point::new(100, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,
@@ -117,9 +117,9 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::bar(
                     current.clone(),
                     ui.draw_target.clone(),
-                    Point::new(70, y - 6),
-                    45,
-                    7,
+                    Point::new(130, y - 14),
+                    90,
+                    18,
                     Box::new(|meas: &Measurement| meas.value / 0.5),
                 )
                 .await,

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -20,7 +20,7 @@ use async_std::sync::{Arc, Mutex};
 use async_std::task::{spawn, JoinHandle};
 use async_trait::async_trait;
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X9, MonoFont, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoFont, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Circle, Line, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
@@ -32,7 +32,7 @@ use serde::Serialize;
 use super::FramebufferDrawTarget;
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
-pub const UI_TEXT_FONT: MonoFont = FONT_6X9; // FIXME: Use font 6x8?
+pub const UI_TEXT_FONT: MonoFont = FONT_10X20;
 
 pub enum IndicatorState {
     On,
@@ -254,9 +254,9 @@ impl DynamicWidget<i32> {
         Self::new(
             topic,
             target,
-            Point::new(128 - 5, 32),
+            Point::new(240 - 5, 120),
             Box::new(move |val, anchor, target| {
-                let size = 64 - ((*val - 32).abs() * 2);
+                let size = 128 - (*val - 32).abs() * 4;
 
                 if size != 0 {
                     let bounding = Rectangle::with_center(anchor, Size::new(10, size as u32));


### PR DESCRIPTION
The new display has a far greater resolution (`240x240` instead of `128x64`).
It also has other features like a backlight we can turn off or on and color, but let's not bother with them for now.
Instead just update all hardcoded dimensions with new hardcoded dimensions.

To do before un-drafting:

- [x] Test on actual hardware. Testing was done in the web interface for now.