### PR TITLE
dut_power: add median filter to over/under voltage/current detection

### DIFF
--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -474,6 +474,13 @@ mod tests {
         assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);
         assert_eq!(*block_on(dut_pwr.state.get()), OutputState::On);
 
+        println!("Trigger transient inverted polarity (Output should stay on)");
+        adc.pwr_volt.fast.transient(MIN_VOLTAGE * 1.01);
+        block_on(sleep(Duration::from_millis(500)));
+        assert_eq!(pwr_line.stub_get(), PWR_LINE_ASSERTED);
+        assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);
+        assert_eq!(*block_on(dut_pwr.state.get()), OutputState::On);
+
         println!("Trigger inverted polarity");
         adc.pwr_volt.fast.set(MIN_VOLTAGE * 1.01);
         block_on(sleep(Duration::from_millis(500)));
@@ -493,6 +500,13 @@ mod tests {
         assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);
         assert_eq!(*block_on(dut_pwr.state.get()), OutputState::On);
 
+        println!("Trigger transient overcurrent (Output should stay on)");
+        adc.pwr_curr.fast.transient(MAX_CURRENT * 1.01);
+        block_on(sleep(Duration::from_millis(500)));
+        assert_eq!(pwr_line.stub_get(), PWR_LINE_ASSERTED);
+        assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);
+        assert_eq!(*block_on(dut_pwr.state.get()), OutputState::On);
+
         println!("Trigger overcurrent");
         adc.pwr_curr.fast.set(MAX_CURRENT * 1.01);
         block_on(sleep(Duration::from_millis(500)));
@@ -504,6 +518,13 @@ mod tests {
 
         println!("Turn on again");
         block_on(dut_pwr.request.set(OutputRequest::On));
+        block_on(sleep(Duration::from_millis(500)));
+        assert_eq!(pwr_line.stub_get(), PWR_LINE_ASSERTED);
+        assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);
+        assert_eq!(*block_on(dut_pwr.state.get()), OutputState::On);
+
+        println!("Trigger transient overvoltage (Output should stay on)");
+        adc.pwr_volt.fast.transient(MAX_VOLTAGE * 1.01);
         block_on(sleep(Duration::from_millis(500)));
         assert_eq!(pwr_line.stub_get(), PWR_LINE_ASSERTED);
         assert_eq!(discharge_line.stub_get(), 1 - DISCHARGE_LINE_ASSERTED);


### PR DESCRIPTION
Short transients on these values will not result in damage to the TAC or DUT, so they should be filtered out to prevent the DUT from being turned of due to EMI or inrush current.

Things to do before un-marking as WIP:

- [x] Test on real hardware, preferably in a setup that previously suffered from spurious shutoffs
- [x] Add a unit test