### PR TITLE
dut_power: make OffDischarge the default Off state

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -598,7 +598,7 @@ components:
       enum:
         - On
         - Off
-        - OffDischarge
+        - OffFloating
         - InvertedPolarity
         - OverCurrent
         - OverVoltage
@@ -609,7 +609,7 @@ components:
       enum:
         - On
         - Off
-        - OffDischarge
+        - OffFloating
 
     UsbDevice:
       type: object

--- a/src/ui/power_screen.rs
+++ b/src/ui/power_screen.rs
@@ -109,7 +109,7 @@ impl MountableScreen for PowerScreen {
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => "On".into(),
                     OutputState::Off => "Off".into(),
-                    OutputState::OffDischarge => "Off (Dis.)".into(),
+                    OutputState::OffFloating => "Off (Float.)".into(),
                     OutputState::InvertedPolarity => "Inv. Pol.".into(),
                     OutputState::OverCurrent => "Ov. Curr.".into(),
                     OutputState::OverVoltage => "Ov. Volt.".into(),
@@ -126,7 +126,7 @@ impl MountableScreen for PowerScreen {
                 Point::new(90, 47 - 6),
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => IndicatorState::On,
-                    OutputState::Off | OutputState::OffDischarge => IndicatorState::Off,
+                    OutputState::Off | OutputState::OffFloating => IndicatorState::Off,
                     _ => IndicatorState::Error,
                 }),
             )


### PR DESCRIPTION
… and `OffFloating` special

The voltage measurement on the LXA TAC powerboard is quite high impedance. This is rather nice, as it means we do not load the power supply etc. What's not nice is that it means the measurement is very susceptible to noise, e.g. when no DUT is connected.
This has lead to some confusion in the past.

Just make the low-impedance `OffDischarge` the new `Off` and make `OffFloating` the "I know what I am doing" special case.

Things to do before un-marking as WIP:

- [x] Test on real hardware (via the web UI and the API)