### PR TITLE
digital_io: fix wrong initial state for inverted pins

### DIFF
--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -53,7 +53,7 @@ fn handle_line_wo(
     initial: bool,
     inverted: bool,
 ) -> Arc<Topic<bool>> {
-    let topic = bb.topic_rw(path, Some(initial ^ inverted));
+    let topic = bb.topic_rw(path, Some(initial));
     let line = find_line(line_name).unwrap();
     let dst = line
         .request(LineRequestFlags::OUTPUT, (initial ^ inverted) as _, "tacd")


### PR DESCRIPTION
The DUT UART lines were shown as off in the interface even though they were on.
Controlling them did hower do the right thing.