### PR TITLE
web: allow editing the ssh authorized_keys from the web interface

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,11 @@ async fn main() -> Result<(), std::io::Error> {
         );
         web_interface.expose_file_rw("/etc/labgrid/environment", "/v1/labgrid/environment");
         web_interface.expose_file_rw("/etc/labgrid/userconfig.yaml", "/v1/labgrid/userconfig");
+
+        web_interface.expose_file_rw(
+            "/home/root/.ssh/authorized_keys",
+            "/v1/tac/ssh/authorized_keys",
+        );
     }
 
     log::info!("Setup complete. Handling requests");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -79,6 +79,7 @@ function Navigation() {
             text: "Settings",
             items: [
               { type: "link", text: "Labgrid", href: "#/settings/labgrid" },
+              { type: "link", text: "SSH", href: "#/settings/ssh" },
             ],
           },
           {

--- a/web/src/ConfigEditor.tsx
+++ b/web/src/ConfigEditor.tsx
@@ -1,0 +1,140 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import "ace-builds/src-noconflict/ace"; // Load Ace Editor
+import { config } from "ace-builds/src-noconflict/ace";
+
+import Button from "@cloudscape-design/components/button";
+import Form from "@cloudscape-design/components/form";
+import CodeEditor, {
+  CodeEditorProps,
+} from "@cloudscape-design/components/code-editor";
+
+import { useEffect, useState } from "react";
+
+// Make sure to only require (and thus pack using webpack) modules that are
+// actually used.
+// Requiring with file-loader returns a URL (this is different from what
+// require usually does, e.g. returning an object).
+// This behaviour is borrowed from ace webpack-resolver.js, which does however
+// result in each and every ace module landing in our build directory.
+// eslint is really not okay with us using require like that but I currently
+// do not know how to do it right without modiying webpack.config.js which
+// requires opening a whole other can of worms.
+const aceModules: { [name: string]: string } = {
+  // eslint-disable-next-line
+  "ace/mode/yaml_worker": require("file-loader?esModule=false!ace-builds/src-noconflict/worker-yaml.js"),
+  // eslint-disable-next-line
+  "ace/theme/dawn": require("file-loader?esModule=false!ace-builds/src-noconflict/theme-dawn.js"),
+  // eslint-disable-next-line
+  "ace/mode/yaml": require("file-loader?esModule=false!ace-builds/src-noconflict/mode-yaml.js"),
+  // eslint-disable-next-line
+  "ace/mode/sh": require("file-loader?esModule=false!ace-builds/src-noconflict/mode-sh.js"),
+  // eslint-disable-next-line
+  "ace/ext/language_tools": require("file-loader?esModule=false!ace-builds/src-noconflict/ext-language_tools.js"),
+  // eslint-disable-next-line
+  "ace/snippets/sh": require("file-loader?esModule=false!ace-builds/src-noconflict/snippets/sh.js"),
+};
+
+// Only here to silence the error in the browser console telling us that
+// he basePath from which to load modules is not set.
+// (We don't care, as we will use our own moduleUrl resolving function)
+config.set("basePath", "/");
+
+config.moduleUrl = function (name: string, component?: string) {
+  let url = aceModules[name];
+
+  if (url === undefined) {
+    console.log("Missing ace module ", name, component);
+  }
+
+  return aceModules[name];
+};
+
+type ConfigEditorProps = {
+  path: string;
+  language: CodeEditorProps.Language;
+};
+
+export function ConfigEditor(props: ConfigEditorProps) {
+  const [preferences, setPreferences] = useState<
+    CodeEditorProps.Preferences | undefined
+  >(undefined);
+
+  const [content, setContent] = useState<string | undefined>();
+  const [newContent, setNewContent] = useState<string | undefined>();
+
+  function loadContent() {
+    fetch(props.path)
+      .then((response) => response.text())
+      .then((text) => setContent(text));
+  }
+
+  useEffect(() => {
+    loadContent();
+    // eslint-disable-next-line
+  }, []);
+
+  function save() {
+    if (newContent !== undefined) {
+      setContent(undefined);
+
+      fetch(props.path, { method: "PUT", body: newContent }).then(() =>
+        loadContent()
+      );
+    }
+  }
+
+  return (
+    <Form
+      actions={
+        <Button formAction="none" variant="primary" onClick={save}>
+          Save
+        </Button>
+      }
+    >
+      <CodeEditor
+        ace={ace}
+        language={props.language}
+        value={content || ""}
+        preferences={preferences}
+        onPreferencesChange={(e) => setPreferences(e.detail)}
+        onDelayedChange={(e) => setNewContent(e.detail.value)}
+        loading={content === undefined}
+        i18nStrings={{
+          loadingState: "Loading code editor",
+          errorState: "There was an error loading the code editor.",
+          errorStateRecovery: "Retry",
+          editorGroupAriaLabel: "Code editor",
+          statusBarGroupAriaLabel: "Status bar",
+          cursorPosition: (row, column) => `Ln ${row}, Col ${column}`,
+          errorsTab: "Errors",
+          warningsTab: "Warnings",
+          preferencesButtonAriaLabel: "Preferences",
+          paneCloseButtonAriaLabel: "Close",
+          preferencesModalHeader: "Preferences",
+          preferencesModalCancel: "Cancel",
+          preferencesModalConfirm: "Confirm",
+          preferencesModalWrapLines: "Wrap lines",
+          preferencesModalTheme: "Theme",
+          preferencesModalLightThemes: "Light themes",
+          preferencesModalDarkThemes: "Dark themes",
+        }}
+      />
+    </Form>
+  );
+}

--- a/web/src/LandingPage.tsx
+++ b/web/src/LandingPage.tsx
@@ -68,6 +68,11 @@ export default function LandingPage() {
             description: "Modify the Labgrid exporter config",
           },
           {
+            name: "Settings / SSH",
+            href: "/#/settings/ssh",
+            description: "Modify the SSH server config",
+          },
+          {
             name: "Documentation / REST API",
             href: "/#/docs/api",
             description: "Find API definitions to automate you LXA TAC",

--- a/web/src/SettingsLabgrid.tsx
+++ b/web/src/SettingsLabgrid.tsx
@@ -15,138 +15,17 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import "ace-builds/src-noconflict/ace"; // Load Ace Editor
-import { config } from "ace-builds/src-noconflict/ace";
-
 import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 import Form from "@cloudscape-design/components/form";
 import Header from "@cloudscape-design/components/header";
 import Container from "@cloudscape-design/components/container";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Tabs from "@cloudscape-design/components/tabs";
-import CodeEditor, {
-  CodeEditorProps,
-} from "@cloudscape-design/components/code-editor";
-
-import { useEffect, useState } from "react";
 
 import { MqttBox, MqttButton } from "./MqttComponents";
 import { JournalView } from "./DashboardJournal";
-
-// Make sure to only require (and thus pack using webpack) modules that are
-// actually used.
-// Requiring with file-loader returns a URL (this is different from what
-// require usually does, e.g. returning an object).
-// This behaviour is borrowed from ace webpack-resolver.js, which does however
-// result in each and every ace module landing in our build directory.
-// eslint is really not okay with us using require like that but I currently
-// do not know how to do it right without modiying webpack.config.js which
-// requires opening a whole other can of worms.
-const aceModules: { [name: string]: string } = {
-  // eslint-disable-next-line
-  "ace/mode/yaml_worker": require("file-loader?esModule=false!ace-builds/src-noconflict/worker-yaml.js"),
-  // eslint-disable-next-line
-  "ace/theme/dawn": require("file-loader?esModule=false!ace-builds/src-noconflict/theme-dawn.js"),
-  // eslint-disable-next-line
-  "ace/mode/yaml": require("file-loader?esModule=false!ace-builds/src-noconflict/mode-yaml.js"),
-  // eslint-disable-next-line
-  "ace/mode/sh": require("file-loader?esModule=false!ace-builds/src-noconflict/mode-sh.js"),
-  // eslint-disable-next-line
-  "ace/ext/language_tools": require("file-loader?esModule=false!ace-builds/src-noconflict/ext-language_tools.js"),
-  // eslint-disable-next-line
-  "ace/snippets/sh": require("file-loader?esModule=false!ace-builds/src-noconflict/snippets/sh.js"),
-};
-
-// Only here to silence the error in the browser console telling us that
-// he basePath from which to load modules is not set.
-// (We don't care, as we will use our own moduleUrl resolving function)
-config.set("basePath", "/");
-
-config.moduleUrl = function (name: string, component?: string) {
-  let url = aceModules[name];
-
-  if (url === undefined) {
-    console.log("Missing ace module ", name, component);
-  }
-
-  return aceModules[name];
-};
-
-type ConfigEditorProps = {
-  path: string;
-  language: CodeEditorProps.Language;
-};
-
-function ConfigEditor(props: ConfigEditorProps) {
-  const [preferences, setPreferences] = useState<
-    CodeEditorProps.Preferences | undefined
-  >(undefined);
-
-  const [content, setContent] = useState<string | undefined>();
-  const [newContent, setNewContent] = useState<string | undefined>();
-
-  function loadContent() {
-    fetch(props.path)
-      .then((response) => response.text())
-      .then((text) => setContent(text));
-  }
-
-  useEffect(() => {
-    loadContent();
-    // eslint-disable-next-line
-  }, []);
-
-  function save() {
-    if (newContent !== undefined) {
-      setContent(undefined);
-
-      fetch(props.path, { method: "PUT", body: newContent }).then(() =>
-        loadContent()
-      );
-    }
-  }
-
-  return (
-    <Form
-      actions={
-        <Button formAction="none" variant="primary" onClick={save}>
-          Save
-        </Button>
-      }
-    >
-      <CodeEditor
-        ace={ace}
-        language={props.language}
-        value={content || ""}
-        preferences={preferences}
-        onPreferencesChange={(e) => setPreferences(e.detail)}
-        onDelayedChange={(e) => setNewContent(e.detail.value)}
-        loading={content === undefined}
-        i18nStrings={{
-          loadingState: "Loading code editor",
-          errorState: "There was an error loading the code editor.",
-          errorStateRecovery: "Retry",
-          editorGroupAriaLabel: "Code editor",
-          statusBarGroupAriaLabel: "Status bar",
-          cursorPosition: (row, column) => `Ln ${row}, Col ${column}`,
-          errorsTab: "Errors",
-          warningsTab: "Warnings",
-          preferencesButtonAriaLabel: "Preferences",
-          paneCloseButtonAriaLabel: "Close",
-          preferencesModalHeader: "Preferences",
-          preferencesModalCancel: "Cancel",
-          preferencesModalConfirm: "Confirm",
-          preferencesModalWrapLines: "Wrap lines",
-          preferencesModalTheme: "Theme",
-          preferencesModalLightThemes: "Light themes",
-          preferencesModalDarkThemes: "Dark themes",
-        }}
-      />
-    </Form>
-  );
-}
+import { ConfigEditor } from "./ConfigEditor";
 
 type ServiceStatus = {
   active_state: string;

--- a/web/src/SettingsSSH.tsx
+++ b/web/src/SettingsSSH.tsx
@@ -1,0 +1,54 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import Box from "@cloudscape-design/components/box";
+import Header from "@cloudscape-design/components/header";
+import Container from "@cloudscape-design/components/container";
+import SpaceBetween from "@cloudscape-design/components/space-between";
+import Tabs from "@cloudscape-design/components/tabs";
+
+import { ConfigEditor } from "./ConfigEditor";
+
+export default function SettingsSSH() {
+  return (
+    <SpaceBetween size="m">
+      <Header variant="h1" description="Configure the SSH server">
+        LXA TAC / SSH Settings
+      </Header>
+
+      <Container
+        header={
+          <Header variant="h2" description="Edit the SSH server config">
+            Config Files
+          </Header>
+        }
+      >
+        <Tabs
+          tabs={[
+            {
+              label: "Authorized Keys for root",
+              id: "user",
+              content: (
+                <ConfigEditor path="/v1/tac/ssh/authorized_keys" language="text" />
+              ),
+            },
+          ]}
+        />
+      </Container>
+    </SpaceBetween>
+  );
+}

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -29,6 +29,7 @@ import DashboardJournal from "./DashboardJournal";
 import DashboardTac from "./DashboardTac";
 import LandingPage from "./LandingPage";
 import SettingsLabgrid from "./SettingsLabgrid";
+import SettingsSSH from "./SettingsSSH";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -43,6 +44,7 @@ root.render(
           <Route path="/dashboard/journal" element={<DashboardJournal />} />
           <Route path="/dashboard/tac" element={<DashboardTac />} />
           <Route path="/settings/labgrid" element={<SettingsLabgrid />} />
+          <Route path="/settings/ssh" element={<SettingsSSH />} />
           <Route path="/docs/api" element={<ApiDocs />} />
         </Route>
       </Routes>


### PR DESCRIPTION
This PR adds the `authorized_keys` file for root to the list of config files that can be edited from the web interface.

![tacd-webui-authorized_keys](https://user-images.githubusercontent.com/1273320/219020722-7cdf943d-4219-4b96-9515-99a9bbe44e80.png)

I've stumbled over the need for something like this while writing the LXA TAC quick start guide, as there needs to be some way to first get access to the TAC.

This has obvious and serious security implications, as anyone who can access the web interface can now gain root on the device.
This is a feature in plain sight and anyone setting up a TAC for the first time will get across it, so at least it is not like some telnet port with default passwords on some other IoT devices.
Instead the clear message is _"everyone on a network with a TAC can do whatever they want with it (design your network accordingly)"_.
At least until we get around to implementing proper authentication.