### PR TITLE
Add GitHub Workflows for Deamon and Web UI

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -1,0 +1,85 @@
+name: tacd
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'web/**'
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install libsystemd-dev libiio-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install libsystemd-dev libiio-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+          name: Clippy Output
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command-arguments: --hide-inclusion-graph bans licenses sources
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install libsystemd-dev libiio-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -1,0 +1,54 @@
+name: tacd-webui
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/tacd-webui.yaml'
+      - 'web/**'
+  push:
+    branches:
+      - main
+
+jobs:
+  prettier:
+    name: npx prettier
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+      - run: npx prettier --check .
+
+  license:
+    name: npx license-checker
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+      - name: npx license-checker
+        run: >
+          npx license-checker --summary --excludePrivatePackages --onlyAllow
+          "0BSD;Apache-2.0;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;CC0-1.0;EPL-1.0;ISC;MIT;MPL-2.0;Python-2.0;Unlicense;WTFPL"
+
+  build:
+    name: npm run build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
Add GitHub Workflows that for the …

* … tacd daemon …
  * … runs cargo check to make sure that a Pull Request is buildable.
  * … runs cargo fmt to make sure the PR is well formatted.
  * … runs cargo clippy to add annotations to the PR about possible improvements.
  * … runs cargo test to execute the (currently rather small) test suite.
* … tacd web interface …
  * … run npx prettiert to check if the typescript code base is well formatted.
  * … run npm run build to check if the web interface is buildable.

I can think of some more interesting actions, but this should be a good starting point.

The current codebase contains enough … *errr* … test cases for these workflows to generate some output.