### PR TITLE
Add more feature-full demo mode

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -25,6 +25,22 @@ jobs:
         with:
           command: check
 
+  check-demo:
+    name: cargo check demo_mode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features=demo_mode --no-default-features
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "nix 0.24.2",
  "png",
  "pretty_env_logger",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,28 +51,7 @@ zvariant = { version = "3", default-features = false, features = ["enumflags2"] 
 
 [features]
 default = ["systemd"]
-stub_out_adc = []
-stub_out_barebox = []
-stub_out_display = []
-stub_out_dbus = []
-stub_out_evdev = []
-stub_out_fs = []
-stub_out_gpio = []
-stub_out_hwmon = []
-stub_out_root = []
-stub_out_usb_hub = []
-stub_out_everything = [
-  "stub_out_adc",
-  "stub_out_barebox",
-  "stub_out_display",
-  "stub_out_dbus",
-  "stub_out_evdev",
-  "stub_out_fs",
-  "stub_out_gpio",
-  "stub_out_hwmon",
-  "stub_out_root",
-  "stub_out_usb_hub",
-]
+demo_mode = []
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ mqtt-protocol = "0.11.2"
 nix = "0.24"
 png = "0.17"
 pretty_env_logger = "0.4"
+rand = { version = "0.8", optional = true}
 serde_json = "1.0"
 serde_repr = "0.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -51,7 +52,7 @@ zvariant = { version = "3", default-features = false, features = ["enumflags2"] 
 
 [features]
 default = ["systemd"]
-demo_mode = []
+demo_mode = ["rand"]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ TAC, this means that the full `tacd` can not run on a non-TAC system.
 
 You can however run a stripped-down version by using:
 
-    $ cargo run --features=stub_out_everything --no-default-features
+    $ cargo run --features=demo_mode --no-default-features
 
 Note that rust will complain very loudly about a lot of dead code,
 which is not used when building for PC but used on the TAC.

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -26,13 +26,13 @@ use crate::broker::{BrokerBuilder, Topic};
 
 const HISTORY_LENGTH: usize = 200;
 
-#[cfg(any(test, feature = "stub_out_adc"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod iio {
     mod stub;
     pub use stub::*;
 }
 
-#[cfg(not(any(test, feature = "stub_out_adc")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod iio {
     mod hardware;
     pub use hardware::*;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -26,10 +26,16 @@ use crate::broker::{BrokerBuilder, Topic};
 
 const HISTORY_LENGTH: usize = 200;
 
-#[cfg(any(test, feature = "demo_mode"))]
+#[cfg(test)]
 mod iio {
-    mod stub;
-    pub use stub::*;
+    mod test;
+    pub use test::*;
+}
+
+#[cfg(feature = "demo_mode")]
+mod iio {
+    mod demo_mode;
+    pub use demo_mode::*;
 }
 
 #[cfg(not(any(test, feature = "demo_mode")))]

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -1,0 +1,194 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::convert::TryFrom;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
+
+use anyhow::{anyhow, Result};
+use async_std::sync::{Arc, Mutex};
+use async_std::task::block_on;
+use rand::{thread_rng, Rng};
+
+// We need to somehow get the output states from digital_io/gpio/demo_mode.rs
+// to here. We could clobber the actual business code even more, or do dirty
+// mutable globals stuff.
+pub static DEMO_MAGIC: Mutex<Option<Arc<IioThread>>> = Mutex::new(None);
+
+pub struct CalibratedChannelInner {
+    name: &'static str,
+    timebase: Instant,
+    state: AtomicBool,
+    last_poll_ms: AtomicU64,
+    value: AtomicU32,
+    nominal_value_on: f32,
+    nominal_value_off: f32,
+    noise: f32,
+    time_constant_on: f32,
+    time_constant_off: f32,
+    parents: Vec<CalibratedChannel>,
+}
+
+#[derive(Clone)]
+pub struct CalibratedChannel {
+    inner: Arc<CalibratedChannelInner>,
+}
+
+impl CalibratedChannel {
+    pub fn with_exponential(
+        name: &'static str,
+        nominal_value_on: f32,
+        nominal_value_off: f32,
+        noise: f32,
+        time_constant_on: f32,
+        time_constant_off: f32,
+    ) -> Self {
+        Self {
+            inner: Arc::new(CalibratedChannelInner {
+                name,
+                timebase: Instant::now(),
+                state: AtomicBool::new(false),
+                last_poll_ms: AtomicU64::new(0),
+                value: AtomicU32::new(nominal_value_off.to_bits()),
+                nominal_value_on,
+                nominal_value_off,
+                noise,
+                time_constant_on,
+                time_constant_off,
+                parents: Vec::new(),
+            }),
+        }
+    }
+
+    pub fn with_parents(name: &'static str, parents: Vec<CalibratedChannel>) -> Self {
+        Self {
+            inner: Arc::new(CalibratedChannelInner {
+                name,
+                timebase: Instant::now(),
+                state: AtomicBool::new(false),
+                last_poll_ms: AtomicU64::new(0),
+                value: AtomicU32::new(0),
+                nominal_value_on: 0.0,
+                nominal_value_off: 0.0,
+                noise: 0.0,
+                time_constant_on: 0.0,
+                time_constant_off: 0.0,
+                parents: parents,
+            }),
+        }
+    }
+
+    pub fn try_get_multiple<const N: usize>(
+        &self,
+        channels: [&Self; N],
+    ) -> Option<(Instant, [f32; N])> {
+        let mut results = [0.0; N];
+
+        for i in 0..N {
+            results[i] = channels[i].get().1;
+        }
+
+        let ts = Instant::now();
+
+        Some((ts, results))
+    }
+
+    pub fn get(&self) -> (Instant, f32) {
+        let now = Instant::now();
+
+        let dt = {
+            let runtime = now.duration_since(self.inner.timebase);
+
+            let runtime_ms = u64::try_from(runtime.as_millis()).unwrap();
+            let last_poll_ms = self.inner.last_poll_ms.swap(runtime_ms, Ordering::Relaxed);
+
+            (runtime_ms - last_poll_ms) as f32 / 1000.0
+        };
+
+        let (nominal, time_constant) = match self.inner.state.load(Ordering::Relaxed) {
+            true => (self.inner.nominal_value_on, self.inner.time_constant_on),
+            false => (self.inner.nominal_value_off, self.inner.time_constant_off),
+        };
+
+        let mut value = f32::from_bits(self.inner.value.load(Ordering::Relaxed));
+
+        value -= nominal;
+        value *= (-dt / time_constant).exp();
+        value += (2.0 * thread_rng().gen::<f32>() - 1.0) * self.inner.noise;
+        value += self.inner.parents.iter().map(|p| p.get().1).sum::<f32>();
+        value += nominal;
+
+        self.inner.value.store(value.to_bits(), Ordering::Relaxed);
+
+        (now, value)
+    }
+
+    pub fn set(&self, state: bool) {
+        self.inner.state.store(state, Ordering::Relaxed);
+    }
+}
+
+pub struct IioThread {
+    channels: Vec<CalibratedChannel>,
+}
+
+impl IioThread {
+    pub fn new() -> Arc<Self> {
+        let mut demo_magic = block_on(DEMO_MAGIC.lock());
+
+        // Only ever set up a single demo_mode "IioThread"
+        if let Some(this) = &*demo_magic {
+            return this.clone();
+        }
+
+        let usb_host_curr = CalibratedChannel::with_parents(
+            "usb-host-curr",
+            vec![
+                CalibratedChannel::with_exponential("usb-host1-curr", 0.15, 0.005, 0.005, 0.3, 0.2),
+                CalibratedChannel::with_exponential("usb-host2-curr", 0.2, 0.005, 0.005, 0.3, 0.2),
+                CalibratedChannel::with_exponential("usb-host3-curr", 0.3, 0.005, 0.005, 0.3, 0.2),
+            ],
+        );
+
+        let channels = vec![
+            usb_host_curr.clone(),
+            usb_host_curr.inner.parents[0].clone(),
+            usb_host_curr.inner.parents[1].clone(),
+            usb_host_curr.inner.parents[2].clone(),
+            CalibratedChannel::with_exponential("out0-volt", 0.0, 3.3, 0.002, 0.1, 0.2),
+            CalibratedChannel::with_exponential("out1-volt", 0.0, -3.3, 0.002, 0.2, 0.1),
+            CalibratedChannel::with_exponential("iobus-curr", 0.15, 0.0, 0.001, 0.2, 0.01),
+            CalibratedChannel::with_exponential("iobus-volt", 12.2, 0.0, 0.1, 0.2, 1.0),
+            CalibratedChannel::with_exponential("pwr-volt", 24.0, 0.0, 0.02, 0.2, 2.0),
+            CalibratedChannel::with_exponential("pwr-curr", 1.2, 0.0, 0.002, 0.2, 0.01),
+        ];
+
+        let this = Arc::new(Self { channels });
+
+        *demo_magic = Some(this.clone());
+
+        this
+    }
+
+    pub fn get_channel(self: Arc<Self>, ch_name: &str) -> Result<CalibratedChannel> {
+        self.channels
+            .iter()
+            .find(|chan| chan.inner.name == ch_name)
+            .ok_or(anyhow!("Could not get adc channel {}", ch_name))
+            .cloned()
+    }
+}

--- a/src/adc/iio/stub.rs
+++ b/src/adc/iio/stub.rs
@@ -91,14 +91,17 @@ impl CalibratedChannel {
         }
     }
 
+    #[cfg(test)]
     pub fn set(&self, val: f32) {
         self.val.store(val.to_bits(), Ordering::Relaxed)
     }
 
+    #[cfg(test)]
     pub fn stall(&self, state: bool) {
         self.stall.store(state, Ordering::Relaxed)
     }
 
+    #[cfg(test)]
     pub fn transient(&self, val: f32) {
         self.transient.store(val.to_bits(), Ordering::Relaxed)
     }

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -1,0 +1,129 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+use async_std::sync::Arc;
+
+const NO_TRANSIENT: u32 = u32::MAX;
+
+const CHANNELS: &[&str] = &[
+    "usb-host-curr",
+    "usb-host1-curr",
+    "usb-host2-curr",
+    "usb-host3-curr",
+    "out0-volt",
+    "out1-volt",
+    "iobus-curr",
+    "iobus-volt",
+    "pwr-volt",
+    "pwr-curr",
+];
+
+#[derive(Clone)]
+pub struct CalibratedChannel {
+    val: Arc<AtomicU32>,
+    stall: Arc<AtomicBool>,
+    transient: Arc<AtomicU32>,
+}
+
+impl CalibratedChannel {
+    fn new() -> Self {
+        Self {
+            val: Arc::new(AtomicU32::new(0)),
+            stall: Arc::new(AtomicBool::new(false)),
+            transient: Arc::new(AtomicU32::new(NO_TRANSIENT)),
+        }
+    }
+
+    pub fn try_get_multiple<const N: usize>(
+        &self,
+        channels: [&Self; N],
+    ) -> Option<(Instant, [f32; N])> {
+        let mut results = [0.0; N];
+
+        for i in 0..N {
+            // If a transient is scheduled (channels[i].transient != NO_TRANSIENT)
+            // output it exactly once. Otherwise output the normal value.
+            let transient_u32 = channels[i].transient.swap(NO_TRANSIENT, Ordering::Relaxed);
+            let val_u32 = match transient_u32 {
+                NO_TRANSIENT => channels[i].val.load(Ordering::Relaxed),
+                transient => transient,
+            };
+
+            results[i] = f32::from_bits(val_u32);
+        }
+
+        let mut ts = Instant::now();
+
+        if self.stall.load(Ordering::Relaxed) {
+            ts -= Duration::from_millis(500)
+        }
+
+        Some((ts, results))
+    }
+
+    pub fn try_get(&self) -> Option<(Instant, f32)> {
+        self.try_get_multiple([self]).map(|(ts, [val])| (ts, val))
+    }
+
+    pub fn get(&self) -> (Instant, f32) {
+        loop {
+            if let Some(r) = self.try_get() {
+                break r;
+            }
+        }
+    }
+
+    pub fn set(&self, val: f32) {
+        self.val.store(val.to_bits(), Ordering::Relaxed)
+    }
+
+    pub fn stall(&self, state: bool) {
+        self.stall.store(state, Ordering::Relaxed)
+    }
+
+    pub fn transient(&self, val: f32) {
+        self.transient.store(val.to_bits(), Ordering::Relaxed)
+    }
+}
+
+pub struct IioThread {
+    channels: Vec<(&'static str, CalibratedChannel)>,
+}
+
+impl IioThread {
+    pub fn new() -> Arc<Self> {
+        let mut channels = Vec::new();
+
+        for name in CHANNELS {
+            channels.push((*name, CalibratedChannel::new()))
+        }
+
+        Arc::new(Self { channels })
+    }
+
+    pub fn get_channel(self: Arc<Self>, ch_name: &str) -> Result<CalibratedChannel> {
+        self.channels
+            .iter()
+            .find(|(name, _)| *name == ch_name)
+            .ok_or(anyhow!("Could not get adc channel {}", ch_name))
+            .map(|(_, chan)| chan.clone())
+    }
+}

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -19,7 +19,7 @@ use async_std::sync::Arc;
 
 use crate::broker::BrokerBuilder;
 
-#[cfg(feature = "stub_out_dbus")]
+#[cfg(feature = "demo_mode")]
 mod zb {
     pub type Result<T> = std::result::Result<T, ()>;
 
@@ -45,7 +45,7 @@ mod zb {
     }
 }
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 mod zb {
     pub use zbus::*;
 }

--- a/src/dbus/networkmanager/mod.rs
+++ b/src/dbus/networkmanager/mod.rs
@@ -263,7 +263,7 @@ impl Network {
         let this = Self::setup_topics(bb, "lxatac".to_string());
 
         this.bridge_interface
-            .set(vec![String::from("0.0.0.0")])
+            .set(vec![String::from("192.168.1.1")])
             .await;
         this.dut_interface
             .set(LinkInfo {
@@ -273,7 +273,7 @@ impl Network {
             .await;
         this.uplink_interface
             .set(LinkInfo {
-                speed: 1337,
+                speed: 1000,
                 carrier: true,
             })
             .await;

--- a/src/dbus/networkmanager/mod.rs
+++ b/src/dbus/networkmanager/mod.rs
@@ -245,7 +245,7 @@ impl Network {
         }
     }
 
-    #[cfg(feature = "stub_out_dbus")]
+    #[cfg(feature = "demo_mode")]
     pub async fn new<C>(bb: &mut BrokerBuilder, _conn: C) -> Self {
         let this = Self::setup_topics(bb, "lxatac".to_string());
 
@@ -268,7 +268,7 @@ impl Network {
         this
     }
 
-    #[cfg(not(feature = "stub_out_dbus"))]
+    #[cfg(not(feature = "demo_mode"))]
     pub async fn new(bb: &mut BrokerBuilder, conn: &Arc<Connection>) -> Self {
         let hostname = hostname::HostnameProxy::new(&conn)
             .await

--- a/src/dbus/networkmanager/mod.rs
+++ b/src/dbus/networkmanager/mod.rs
@@ -15,17 +15,23 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+#[cfg(not(feature = "demo_mode"))]
 use std::convert::TryInto;
 
+#[cfg(not(feature = "demo_mode"))]
 use anyhow;
 use async_std;
+#[cfg(not(feature = "demo_mode"))]
 use async_std::stream::StreamExt;
 use async_std::sync::Arc;
-use async_std::task::spawn;
+#[cfg(not(feature = "demo_mode"))]
 use futures::{future::FutureExt, pin_mut, select};
+#[cfg(not(feature = "demo_mode"))]
 use zbus::{Connection, PropertyStream};
+#[cfg(not(feature = "demo_mode"))]
 use zvariant::{ObjectPath, OwnedObjectPath};
 
+#[cfg(not(feature = "demo_mode"))]
 use log::trace;
 use serde::{Deserialize, Serialize};
 
@@ -50,6 +56,7 @@ impl Default for LinkInfo {
     }
 }
 
+#[cfg(not(feature = "demo_mode"))]
 async fn path_from_interface(con: &Connection, interface: &str) -> anyhow::Result<OwnedObjectPath> {
     let proxy = networkmanager::NetworkManagerProxy::new(&con).await?;
     let device_paths = proxy.get_devices().await?;
@@ -70,6 +77,7 @@ async fn path_from_interface(con: &Connection, interface: &str) -> anyhow::Resul
     Err(anyhow::anyhow!("No interface found: {}", interface))
 }
 
+#[cfg(not(feature = "demo_mode"))]
 async fn get_link_info(con: &Connection, path: &str) -> anyhow::Result<LinkInfo> {
     let eth_proxy = devices::WiredProxy::builder(&con)
         .path(path)?
@@ -84,6 +92,7 @@ async fn get_link_info(con: &Connection, path: &str) -> anyhow::Result<LinkInfo>
     Ok(info)
 }
 
+#[cfg(not(feature = "demo_mode"))]
 pub async fn get_ip4_address<'a, P>(con: &Connection, path: P) -> anyhow::Result<Vec<String>>
 where
     P: TryInto<ObjectPath<'a>>,
@@ -105,6 +114,7 @@ where
     Ok(Vec::from([ip_address.to_string()]))
 }
 
+#[cfg(not(feature = "demo_mode"))]
 pub struct LinkStream<'a> {
     pub interface: String,
     _con: Arc<Connection>,
@@ -113,6 +123,7 @@ pub struct LinkStream<'a> {
     data: LinkInfo,
 }
 
+#[cfg(not(feature = "demo_mode"))]
 impl<'a> LinkStream<'a> {
     pub async fn new(con: Arc<Connection>, interface: &str) -> anyhow::Result<LinkStream<'a>> {
         let path = path_from_interface(&con, interface)
@@ -168,6 +179,7 @@ impl<'a> LinkStream<'a> {
     }
 }
 
+#[cfg(not(feature = "demo_mode"))]
 pub struct IpStream<'a> {
     pub interface: String,
     _con: Arc<Connection>,
@@ -175,6 +187,7 @@ pub struct IpStream<'a> {
     path: String,
 }
 
+#[cfg(not(feature = "demo_mode"))]
 impl<'a> IpStream<'a> {
     pub async fn new(con: Arc<Connection>, interface: &str) -> anyhow::Result<IpStream<'a>> {
         let path = path_from_interface(&con, interface)
@@ -283,7 +296,7 @@ impl Network {
             let conn = conn.clone();
             let mut nm_interface = LinkStream::new(conn, "dut").await.unwrap();
             let dut_interface = this.dut_interface.clone();
-            spawn(async move {
+            async_std::task::spawn(async move {
                 dut_interface.set(nm_interface.now()).await;
 
                 while let Ok(info) = nm_interface.next().await {
@@ -296,7 +309,7 @@ impl Network {
             let conn = conn.clone();
             let mut nm_interface = LinkStream::new(conn, "uplink").await.unwrap();
             let uplink_interface = this.uplink_interface.clone();
-            spawn(async move {
+            async_std::task::spawn(async move {
                 uplink_interface.set(nm_interface.now()).await;
 
                 while let Ok(info) = nm_interface.next().await {
@@ -309,7 +322,7 @@ impl Network {
             let conn = conn.clone();
             let mut nm_interface = IpStream::new(conn.clone(), "tac-bridge").await.unwrap();
             let bridge_interface = this.bridge_interface.clone();
-            spawn(async move {
+            async_std::task::spawn(async move {
                 bridge_interface
                     .set(nm_interface.now(&conn).await.unwrap())
                     .await;

--- a/src/dbus/rauc/demo_mode.rs
+++ b/src/dbus/rauc/demo_mode.rs
@@ -1,0 +1,83 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use super::SlotStatus;
+
+const SLOT_STATUS: &[u8] = br#"
+{
+  "rootfs_1": {
+    "name": "rootfs.1",
+    "bundle_compatible": "lxatac-lxatac",
+    "bundle_build": "20230222110225",
+    "bundle_version": "4.0-0-20230222110225",
+    "slot_class": "rootfs",
+    "bootname": "system1",
+    "activated_count": "3",
+    "boot_status": "good",
+    "activated_timestamp": "2023-02-22T11:14:25Z",
+    "status": "ok",
+    "state": "inactive",
+    "size": "983375872",
+    "installed_count": "3",
+    "sha256": "8136d2ecaee989a125e8f27bd05128ade5dc10270b4cd8a564cbdedaa38f274b",
+    "bundle_description": "lxatac-core-bundle-base version 1.0-r0",
+    "device": "/dev/disk/by-partuuid/8eb3e87e-2b4e-45e3-888b-2f678662862d",
+    "installed_timestamp": "2023-02-22T11:14:16Z",
+    "fs_type": "ext4"
+  },
+  "bootloader_0": {
+    "bundle_build": "20230222111713",
+    "slot_class": "bootloader",
+    "bundle_compatible": "lxatac-lxatac",
+    "state": "inactive",
+    "sha256": "4e840bcf0b498d2aba040a845d0b2329c9b68396802b2214d5256060824a685f",
+    "fs_type": "boot-emmc",
+    "installed_timestamp": "2023-02-22T11:23:41Z",
+    "device": "/dev/mmcblk1",
+    "bundle_version": "4.0-0-20230222111713",
+    "bundle_description": "lxatac-core-bundle-base version 1.0-r0",
+    "status": "ok",
+    "size": "1310720",
+    "installed_count": "8",
+    "name": "bootloader.0"
+  },
+  "rootfs_0": {
+    "bundle_build": "20230222111713",
+    "name": "rootfs.0",
+    "installed_timestamp": "2023-02-22T11:23:36Z",
+    "activated_timestamp": "2023-02-22T11:23:43Z",
+    "fs_type": "ext4",
+    "installed_count": "5",
+    "state": "booted",
+    "size": "983465984",
+    "sha256": "90bef769359e1ce0a58f10151ff6c7565fb8b1b3955b8cb3dafaa164a7c381fb",
+    "activated_count": "5",
+    "bundle_version": "4.0-0-20230222111713",
+    "status": "ok",
+    "boot_status": "good",
+    "bundle_compatible": "lxatac-lxatac",
+    "bundle_description": "lxatac-core-bundle-base version 1.0-r0",
+    "bootname": "system0",
+    "device": "/dev/disk/by-partuuid/e82e6873-62cc-46fb-90f0-3e936743fa62",
+    "slot_class": "rootfs"
+  }
+}
+"#;
+
+pub fn slot_status() -> SlotStatus {
+    serde_json::from_slice(SLOT_STATUS).unwrap()
+}

--- a/src/dbus/rauc/mod.rs
+++ b/src/dbus/rauc/mod.rs
@@ -29,6 +29,9 @@ use async_std::task::spawn;
 use super::Connection;
 use crate::broker::{BrokerBuilder, Topic};
 
+#[cfg(feature = "demo_mode")]
+mod demo_mode;
+
 #[cfg(not(feature = "demo_mode"))]
 mod installer;
 
@@ -72,7 +75,13 @@ impl Rauc {
 
     #[cfg(feature = "demo_mode")]
     pub async fn new(bb: &mut BrokerBuilder, _conn: &Arc<Connection>) -> Self {
-        Self::setup_topics(bb)
+        let inst = Self::setup_topics(bb);
+
+        inst.operation.set("idle".to_string()).await;
+        inst.slot_status.set(demo_mode::slot_status()).await;
+        inst.last_error.set("".to_string()).await;
+
+        inst
     }
 
     #[cfg(not(feature = "demo_mode"))]

--- a/src/dbus/rauc/mod.rs
+++ b/src/dbus/rauc/mod.rs
@@ -20,16 +20,16 @@ use std::collections::HashMap;
 use async_std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 use async_std::prelude::*;
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 use async_std::task::spawn;
 
 use super::Connection;
 use crate::broker::{BrokerBuilder, Topic};
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 mod installer;
 
 #[derive(Serialize, Deserialize)]
@@ -70,12 +70,12 @@ impl Rauc {
         }
     }
 
-    #[cfg(feature = "stub_out_dbus")]
+    #[cfg(feature = "demo_mode")]
     pub async fn new(bb: &mut BrokerBuilder, _conn: &Arc<Connection>) -> Self {
         Self::setup_topics(bb)
     }
 
-    #[cfg(not(feature = "stub_out_dbus"))]
+    #[cfg(not(feature = "demo_mode"))]
     pub async fn new(bb: &mut BrokerBuilder, conn: &Arc<Connection>) -> Self {
         let inst = Self::setup_topics(bb);
 

--- a/src/dbus/systemd/mod.rs
+++ b/src/dbus/systemd/mod.rs
@@ -20,19 +20,19 @@ use async_std::sync::Arc;
 use async_std::task::spawn;
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 pub use futures_lite::future::race;
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 pub use log::warn;
 
 use super::{Connection, Result};
 use crate::broker::{BrokerBuilder, Topic};
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 mod manager;
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 mod service;
 
 #[derive(Serialize, Deserialize)]
@@ -65,7 +65,7 @@ pub struct Systemd {
 }
 
 impl ServiceStatus {
-    #[cfg(feature = "stub_out_dbus")]
+    #[cfg(feature = "demo_mode")]
     async fn get() -> Result<Self> {
         Ok(Self {
             active_state: "actvive".to_string(),
@@ -75,7 +75,7 @@ impl ServiceStatus {
         })
     }
 
-    #[cfg(not(feature = "stub_out_dbus"))]
+    #[cfg(not(feature = "demo_mode"))]
     async fn get<'a>(unit: &service::UnitProxy<'a>) -> Result<Self> {
         Ok(Self {
             active_state: unit.active_state().await?,
@@ -94,7 +94,7 @@ impl Service {
         }
     }
 
-    #[cfg(feature = "stub_out_dbus")]
+    #[cfg(feature = "demo_mode")]
     async fn new(
         bb: &mut BrokerBuilder,
         _conn: Arc<Connection>,
@@ -108,7 +108,7 @@ impl Service {
         this
     }
 
-    #[cfg(not(feature = "stub_out_dbus"))]
+    #[cfg(not(feature = "demo_mode"))]
     async fn new(
         bb: &mut BrokerBuilder,
         conn: Arc<Connection>,
@@ -181,7 +181,7 @@ impl Service {
 }
 
 impl Systemd {
-    #[cfg(feature = "stub_out_dbus")]
+    #[cfg(feature = "demo_mode")]
     pub async fn handle_reboot(reboot: Arc<Topic<bool>>, _conn: Arc<Connection>) {
         let (mut reboot_reqs, _) = reboot.subscribe_unbounded().await;
 
@@ -194,7 +194,7 @@ impl Systemd {
         });
     }
 
-    #[cfg(not(feature = "stub_out_dbus"))]
+    #[cfg(not(feature = "demo_mode"))]
     pub async fn handle_reboot(reboot: Arc<Topic<bool>>, conn: Arc<Connection>) {
         let (mut reboot_reqs, _) = reboot.subscribe_unbounded().await;
 

--- a/src/dbus/tacd/mod.rs
+++ b/src/dbus/tacd/mod.rs
@@ -19,7 +19,7 @@ use super::ConnectionBuilder;
 
 pub struct Tacd {}
 
-#[cfg(not(feature = "stub_out_dbus"))]
+#[cfg(not(feature = "demo_mode"))]
 #[zbus::dbus_interface(name = "de.pengutronix.tacd1")]
 impl Tacd {
     fn get_version(&mut self) -> String {

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -19,13 +19,13 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::{block_on, spawn, spawn_blocking};
 
-#[cfg(any(test, feature = "stub_out_gpio"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod gpio {
     mod stub;
     pub use stub::*;
 }
 
-#[cfg(not(any(test, feature = "stub_out_gpio")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod gpio {
     mod hardware;
     pub use hardware::*;

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -19,10 +19,16 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::{block_on, spawn, spawn_blocking};
 
-#[cfg(any(test, feature = "demo_mode"))]
+#[cfg(test)]
 mod gpio {
-    mod stub;
-    pub use stub::*;
+    mod test;
+    pub use test::*;
+}
+
+#[cfg(feature = "demo_mode")]
+mod gpio {
+    mod demo_mode;
+    pub use demo_mode::*;
 }
 
 #[cfg(not(any(test, feature = "demo_mode")))]

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -1,0 +1,135 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::iter::Iterator;
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::adc::IioThread;
+
+pub struct LineHandle {
+    name: String,
+}
+
+impl LineHandle {
+    pub fn set_value(&self, val: u8) -> Result<(), ()> {
+        // This does not actually set up any IIO things.
+        // It is just a hack to let adc/iio/demo_mode.rs
+        // communicate with this function so that toggling an output
+        // has an effect on the measured values.
+        let iio_thread = IioThread::new();
+
+        match self.name.as_str() {
+            "OUT_0" => iio_thread.get_channel("out0-volt").unwrap().set(val != 0),
+            "OUT_1" => iio_thread.get_channel("out1-volt").unwrap().set(val != 0),
+            "IOBUS_PWR_EN" => {
+                iio_thread
+                    .clone()
+                    .get_channel("iobus-curr")
+                    .unwrap()
+                    .set(val != 0);
+                iio_thread.get_channel("iobus-volt").unwrap().set(val != 0);
+            }
+            "IO0" => {
+                iio_thread
+                    .clone()
+                    .get_channel("pwr-curr")
+                    .unwrap()
+                    .set(val == 0);
+                iio_thread.get_channel("pwr-volt").unwrap().set(val == 0);
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+pub struct LineEvent(u8);
+
+impl LineEvent {
+    pub fn event_type(&self) -> EventType {
+        match self.0 {
+            0 => EventType::FallingEdge,
+            _ => EventType::RisingEdge,
+        }
+    }
+}
+
+pub struct LineEventHandle {}
+
+impl LineEventHandle {
+    pub fn get_value(&self) -> Result<u8, ()> {
+        Ok(0)
+    }
+}
+
+impl Iterator for LineEventHandle {
+    type Item = Result<LineEvent, ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            sleep(Duration::from_secs(1000));
+        }
+    }
+}
+
+pub enum EventType {
+    RisingEdge,
+    FallingEdge,
+}
+
+#[allow(non_camel_case_types)]
+pub enum EventRequestFlags {
+    BOTH_EDGES,
+}
+
+pub enum LineRequestFlags {
+    OUTPUT,
+    INPUT,
+}
+
+pub struct FindDecoy {
+    name: String,
+}
+
+impl FindDecoy {
+    pub fn request(&self, _: LineRequestFlags, initial: u8, _: &str) -> Option<LineHandle> {
+        let line_handle = LineHandle {
+            name: self.name.clone(),
+        };
+
+        line_handle.set_value(initial).unwrap();
+
+        Some(line_handle)
+    }
+
+    pub fn events(
+        &self,
+        _: LineRequestFlags,
+        _: EventRequestFlags,
+        _: &str,
+    ) -> Result<LineEventHandle, ()> {
+        Ok(LineEventHandle {})
+    }
+}
+
+pub fn find_line(name: &str) -> Option<FindDecoy> {
+    Some(FindDecoy {
+        name: name.to_string(),
+    })
+}

--- a/src/digital_io/gpio/stub.rs
+++ b/src/digital_io/gpio/stub.rs
@@ -119,6 +119,7 @@ impl FindDecoy {
         })
     }
 
+    #[cfg(test)]
     pub fn stub_get(&self) -> u8 {
         self.val.load(Ordering::Relaxed)
     }

--- a/src/digital_io/gpio/test.rs
+++ b/src/digital_io/gpio/test.rs
@@ -1,0 +1,144 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::iter::Iterator;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::thread::sleep;
+use std::time::Duration;
+
+use async_std::sync::{Arc, Mutex};
+use async_std::task::block_on;
+
+static LINES: Mutex<Vec<(String, Arc<AtomicU8>)>> = Mutex::new(Vec::new());
+
+pub struct LineHandle {
+    name: String,
+    val: Arc<AtomicU8>,
+}
+
+impl LineHandle {
+    pub fn set_value(&self, val: u8) -> Result<(), ()> {
+        println!("GPIO simulation set {} to {}", self.name, val);
+        self.val.store(val, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+pub struct LineEvent(u8);
+
+impl LineEvent {
+    pub fn event_type(&self) -> EventType {
+        match self.0 {
+            0 => EventType::FallingEdge,
+            _ => EventType::RisingEdge,
+        }
+    }
+}
+
+pub struct LineEventHandle {
+    val: Arc<AtomicU8>,
+    prev_val: u8,
+}
+
+impl LineEventHandle {
+    pub fn get_value(&self) -> Result<u8, ()> {
+        Ok(self.val.load(Ordering::Relaxed))
+    }
+}
+
+impl Iterator for LineEventHandle {
+    type Item = Result<LineEvent, ()>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let val = self.val.load(Ordering::Relaxed);
+
+            if val != self.prev_val {
+                self.prev_val = val;
+                return Some(Ok(LineEvent(val)));
+            }
+
+            sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+pub enum EventType {
+    RisingEdge,
+    FallingEdge,
+}
+
+#[allow(non_camel_case_types)]
+pub enum EventRequestFlags {
+    BOTH_EDGES,
+}
+
+pub enum LineRequestFlags {
+    OUTPUT,
+    INPUT,
+}
+
+pub struct FindDecoy {
+    name: String,
+    val: Arc<AtomicU8>,
+}
+
+impl FindDecoy {
+    pub fn request(&self, _: LineRequestFlags, initial: u8, _: &str) -> Option<LineHandle> {
+        self.val.store(initial, Ordering::Relaxed);
+
+        Some(LineHandle {
+            name: self.name.clone(),
+            val: self.val.clone(),
+        })
+    }
+
+    pub fn events(
+        &self,
+        _: LineRequestFlags,
+        _: EventRequestFlags,
+        _: &str,
+    ) -> Result<LineEventHandle, ()> {
+        Ok(LineEventHandle {
+            val: self.val.clone(),
+            prev_val: self.val.load(Ordering::Relaxed),
+        })
+    }
+
+    pub fn stub_get(&self) -> u8 {
+        self.val.load(Ordering::Relaxed)
+    }
+}
+
+pub fn find_line(name: &str) -> Option<FindDecoy> {
+    let val = {
+        let mut lines = block_on(LINES.lock());
+
+        if let Some((_, v)) = lines.iter().find(|(n, _)| n == name) {
+            v.clone()
+        } else {
+            let v = Arc::new(AtomicU8::new(0));
+            lines.push((name.to_string(), v.clone()));
+            v
+        }
+    };
+
+    Some(FindDecoy {
+        name: name.to_string(),
+        val: val,
+    })
+}

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -28,12 +28,12 @@ use crate::adc::AdcChannel;
 use crate::broker::{BrokerBuilder, Topic};
 use crate::digital_io::{find_line, LineHandle, LineRequestFlags};
 
-#[cfg(any(test, feature = "stub_out_root"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod prio {
     pub fn realtime_priority() {}
 }
 
-#[cfg(not(any(test, feature = "stub_out_root")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod prio {
     use std::convert::TryFrom;
     use thread_priority::*;

--- a/src/iobus.rs
+++ b/src/iobus.rs
@@ -21,9 +21,57 @@ use async_std::sync::Arc;
 use async_std::task::{sleep, spawn};
 
 use serde::{Deserialize, Serialize};
-use surf;
 
 use crate::broker::{BrokerBuilder, Topic};
+
+#[cfg(feature = "demo_mode")]
+mod http {
+    use super::{LSSState, Nodes, ServerInfo};
+
+    pub struct RequestDecoy {}
+
+    pub trait DemoModeDefault {
+        fn demo_get() -> Self;
+    }
+
+    impl DemoModeDefault for ServerInfo {
+        fn demo_get() -> Self {
+            Self {
+                hostname: "lxatac-1000".to_string(),
+                started: "some time ago".to_string(),
+                can_interface: "can0".to_string(),
+                can_interface_is_up: true,
+                lss_state: LSSState::Idle,
+                can_tx_error: false,
+            }
+        }
+    }
+
+    impl DemoModeDefault for Nodes {
+        fn demo_get() -> Self {
+            Self {
+                code: 0,
+                error_message: "".to_string(),
+                result: Vec::new(),
+            }
+        }
+    }
+
+    impl RequestDecoy {
+        pub async fn recv_json<T: DemoModeDefault>(&self) -> Result<T, ()> {
+            Ok(T::demo_get())
+        }
+    }
+
+    pub fn get(_: &str) -> RequestDecoy {
+        RequestDecoy {}
+    }
+}
+
+#[cfg(not(feature = "demo_mode"))]
+mod http {
+    pub use surf::get;
+}
 
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]
 pub struct Nodes {
@@ -63,7 +111,7 @@ impl IoBus {
 
         spawn(async move {
             loop {
-                if let Ok(si) = surf::get("http://127.0.0.1:8080/server-info/")
+                if let Ok(si) = http::get("http://127.0.0.1:8080/server-info/")
                     .recv_json::<ServerInfo>()
                     .await
                 {
@@ -80,7 +128,7 @@ impl IoBus {
                         .await;
                 }
 
-                if let Ok(nodes) = surf::get("http://127.0.0.1:8080/nodes/")
+                if let Ok(nodes) = http::get("http://127.0.0.1:8080/nodes/")
                     .recv_json::<Nodes>()
                     .await
                 {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -60,10 +60,6 @@ mod sd {
             Ok(())
         }
 
-        pub fn previous_skip(&mut self, _: u64) -> Result<()> {
-            Ok(())
-        }
-
         pub fn previous_entry(&mut self) -> Result<Option<JournalRecord>> {
             Ok(None)
         }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -25,7 +25,7 @@ use serde_json::to_string;
 use tide::http::Body;
 use tide::{Request, Response, Server};
 
-#[cfg(any(test, feature = "stub_out_root"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod sd {
     use std::collections::btree_map::BTreeMap;
     pub use std::io::Result;
@@ -90,7 +90,7 @@ mod sd {
     }
 }
 
-#[cfg(not(any(test, feature = "stub_out_root")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod sd {
     pub use systemd::journal::*;
     pub use systemd::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), std::io::Error> {
     bb.build(&mut web_interface.server);
     journal::serve(&mut web_interface.server);
 
-    #[cfg(not(feature = "stub_out_fs"))]
+    #[cfg(not(feature = "demo_mode"))]
     {
         web_interface.expose_file_rw(
             "/etc/labgrid/configuration.yaml",

--- a/src/system.rs
+++ b/src/system.rs
@@ -21,18 +21,39 @@ use serde::{Deserialize, Serialize};
 
 use crate::broker::{BrokerBuilder, Topic};
 
-#[cfg(any(test, feature = "demo_mode"))]
+#[cfg(feature = "demo_mode")]
 mod read_dt_props {
-    pub fn read_dt_property(_: &str) -> String {
-        "stub".to_string()
+    const DEMO_DATA_STR: &[(&str, &str)] = &[
+        ("barebox-version", "barebox-2022.11.0-20221121-1"),
+        (
+            "baseboard-factory-data/pcba-hardware-release",
+            "lxatac-S01-R03-B02-C00",
+        ),
+        (
+            "powerboard-factory-data/pcba-hardware-release",
+            "lxatac-S05-R03-V01-C00",
+        ),
+    ];
+
+    const DEMO_DATA_NUM: &[(&str, u32)] = &[
+        ("baseboard-factory-data/modification", 0),
+        ("baseboard-factory-data/factory-timestamp", 1678086417),
+        ("powerboard-factory-data/modification", 0),
+        ("powerboard-factory-data/factory-timestamp", 1678086418),
+    ];
+
+    pub fn read_dt_property(path: &str) -> String {
+        let (_, content) = DEMO_DATA_STR.iter().find(|(p, _)| *p == path).unwrap();
+
+        content.to_string()
     }
 
-    pub fn read_dt_property_u32(_: &str) -> u32 {
-        0
+    pub fn read_dt_property_u32(path: &str) -> u32 {
+        DEMO_DATA_NUM.iter().find(|(p, _)| *p == path).unwrap().1
     }
 }
 
-#[cfg(not(any(test, feature = "demo_mode")))]
+#[cfg(not(feature = "demo_mode"))]
 mod read_dt_props {
     use std::fs::read;
     use std::str::from_utf8;

--- a/src/system.rs
+++ b/src/system.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::broker::{BrokerBuilder, Topic};
 
-#[cfg(any(test, feature = "stub_out_barebox"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod read_dt_props {
     pub fn read_dt_property(_: &str) -> String {
         "stub".to_string()
@@ -32,7 +32,7 @@ mod read_dt_props {
     }
 }
 
-#[cfg(not(any(test, feature = "stub_out_barebox")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod read_dt_props {
     use std::fs::read;
     use std::str::from_utf8;

--- a/src/temperatures.rs
+++ b/src/temperatures.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use async_std::sync::Arc;
 use async_std::task::{block_on, spawn_blocking};
 
-#[cfg(feature = "stub_out_hwmon")]
+#[cfg(feature = "demo_mode")]
 mod hw {
     pub trait SysClass {
         fn input(&self) -> Result<u32, ()>;
@@ -48,7 +48,7 @@ mod hw {
     }
 }
 
-#[cfg(not(feature = "stub_out_hwmon"))]
+#[cfg(not(feature = "demo_mode"))]
 mod hw {
     pub use sysfs_class::*;
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -178,7 +178,7 @@ pub struct Ui {
 /// Spawn a thread that blockingly reads user input and pushes them into
 /// a broker framework topic.
 fn handle_button(path: &'static str, topic: Arc<Topic<ButtonEvent>>) {
-    #[cfg(not(feature = "stub_out_evdev"))]
+    #[cfg(not(feature = "demo_mode"))]
     spawn_blocking(move || {
         let mut device = evdev::Device::open(path).unwrap();
 

--- a/src/ui/draw_fb.rs
+++ b/src/ui/draw_fb.rs
@@ -20,13 +20,13 @@ use std::io::Cursor;
 use embedded_graphics::{pixelcolor::BinaryColor, prelude::*};
 use png::{BitDepth, ColorType, Encoder};
 
-#[cfg(feature = "stub_out_display")]
+#[cfg(feature = "demo_mode")]
 mod backend {
     mod stub;
     pub use stub::*;
 }
 
-#[cfg(not(feature = "stub_out_display"))]
+#[cfg(not(feature = "demo_mode"))]
 mod backend {
     pub use framebuffer::*;
 }

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -29,8 +29,8 @@ use crate::broker::{BrokerBuilder, Topic};
 mod rw {
     use std::collections::HashMap;
     use std::convert::AsRef;
-    use std::io::{Error, ErrorKind, Result};
-    use std::path::{Path, PathBuf};
+    use std::io::Result;
+    use std::path::Path;
     use std::sync::Mutex;
 
     static FILESYSTEM: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::broker::{BrokerBuilder, Topic};
 
-#[cfg(feature = "stub_out_usb_hub")]
+#[cfg(feature = "demo_mode")]
 mod rw {
     use std::collections::HashMap;
     use std::convert::AsRef;
@@ -62,7 +62,7 @@ mod rw {
     }
 }
 
-#[cfg(not(feature = "stub_out_usb_hub"))]
+#[cfg(not(feature = "demo_mode"))]
 mod rw {
     pub use std::fs::*;
 }

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -33,30 +33,75 @@ mod rw {
     use std::path::Path;
     use std::sync::Mutex;
 
+    use crate::adc::IioThread;
+
+    const DEVICES: &[(&str, &str)] = &[
+        ("/1-1-port1/device/idProduct", "1234"),
+        ("/1-1-port1/device/idVendor", "33f7"),
+        ("/1-1-port1/device/manufacturer", "Linux Automation GmbH"),
+        ("/1-1-port1/device/product", "Christmas Tree Ornament"),
+        ("/1-1-port2/device/idProduct", "4321"),
+        ("/1-1-port2/device/idVendor", "33f7"),
+        ("/1-1-port2/device/manufacturer", "Linux Automation GmbH"),
+        ("/1-1-port2/device/product", "LXA Water Hose Mux"),
+        ("/1-1-port3/device/idProduct", "cafe"),
+        ("/1-1-port3/device/idVendor", "33f7"),
+        ("/1-1-port3/device/manufacturer", "Linux Automation GmbH"),
+        ("/1-1-port3/device/product", "Mug warmer"),
+    ];
+
+    const DISABLE_CHANNELS: &[(&str, &str)] = &[
+        ("/1-1-port1/disable", "usb-host1-curr"),
+        ("/1-1-port2/disable", "usb-host2-curr"),
+        ("/1-1-port3/disable", "usb-host3-curr"),
+    ];
+
     static FILESYSTEM: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
 
     pub fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
-        Ok(FILESYSTEM
+        let path = path.as_ref().to_str().unwrap();
+
+        if let Some(stored) = FILESYSTEM
             .lock()
             .unwrap()
             .get_or_insert(HashMap::new())
-            .get(path.as_ref().to_str().unwrap())
+            .get(path)
             .cloned()
-            .unwrap_or(String::from("0")))
+        {
+            return Ok(stored);
+        }
+
+        for (path_tail, content) in DEVICES {
+            if path.ends_with(path_tail) {
+                return Ok(content.to_string());
+            }
+        }
+
+        Ok("0".to_string())
     }
 
     pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
         let path: &Path = path.as_ref();
+        let path = path.to_str().unwrap().to_string();
         let contents: &[u8] = contents.as_ref();
-        let text = std::str::from_utf8(contents).unwrap_or("[Broken UTF-8]");
+        let text = std::str::from_utf8(contents)
+            .unwrap_or("[Broken UTF-8]")
+            .to_string();
+
+        for (path_tail, iio_channel) in DISABLE_CHANNELS {
+            if path.ends_with(path_tail) {
+                IioThread::new()
+                    .get_channel(iio_channel)
+                    .unwrap()
+                    .set(text == "0");
+            }
+        }
 
         FILESYSTEM
             .lock()
             .unwrap()
             .get_or_insert(HashMap::new())
-            .insert(path.to_str().unwrap().to_string(), text.to_string());
-
-        println!("USB: Would write {text} to {path:?} but don't feel like it");
+            .insert(path, text);
 
         Ok(())
     }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -23,7 +23,7 @@ use async_std::task::sleep;
 
 use crate::dut_power::TickReader;
 
-#[cfg(any(test, feature = "stub_out_root"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod sd {
     use std::io::Result;
 
@@ -40,7 +40,7 @@ mod sd {
     }
 }
 
-#[cfg(not(any(test, feature = "stub_out_root")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod sd {
     pub use systemd::daemon::*;
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -16,15 +16,18 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use std::convert::AsRef;
+#[cfg(not(feature = "demo_mode"))]
 use std::fs::write;
 use std::io::ErrorKind;
 use std::net::TcpListener;
 use std::path::Path;
 
 use log::warn;
-use tide::{Body, Request, Response, Server};
+#[cfg(not(feature = "demo_mode"))]
+use tide::Request;
+use tide::{Body, Response, Server};
 
-#[cfg(any(test, feature = "demo_mode"))]
+#[cfg(feature = "demo_mode")]
 mod sd {
     use std::io::Result;
     use std::net::TcpListener;
@@ -42,7 +45,7 @@ mod sd {
     }
 }
 
-#[cfg(not(any(test, feature = "demo_mode")))]
+#[cfg(not(feature = "demo_mode"))]
 mod sd {
     pub use systemd::daemon::*;
 
@@ -145,6 +148,7 @@ impl WebInterface {
     }
 
     /// Serve a file from disk for reading and writing
+    #[cfg(not(feature = "demo_mode"))]
     pub fn expose_file_rw(&mut self, fs_path: &str, web_path: &str) {
         self.server.at(web_path).serve_file(fs_path).unwrap();
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use log::warn;
 use tide::{Body, Request, Response, Server};
 
-#[cfg(any(test, feature = "stub_out_root"))]
+#[cfg(any(test, feature = "demo_mode"))]
 mod sd {
     use std::io::Result;
     use std::net::TcpListener;
@@ -42,7 +42,7 @@ mod sd {
     }
 }
 
-#[cfg(not(any(test, feature = "stub_out_root")))]
+#[cfg(not(any(test, feature = "demo_mode")))]
 mod sd {
     pub use systemd::daemon::*;
 


### PR DESCRIPTION
The `demo_mode` (or `stub_out_everything` as it was previously called) allows one to build and run `tacd` without requiring any of the actual hardware of a LXA TAC.
This greatly simplifies the development of the web interface and in some cases the `tacd` itself, as you can just `cargo run --features=demo_mode --no-default-features` on your host instead of compiling for the TAC, moving files over and running it there.

The `demo_mode` was (and still is) lacking some features compared to a `tacd` running on an actual device, but this PR should close the gap a bit.

The `demo_mode` uses some dirty tricks like global static variables and abusing some interfaces of the normal compilation mode.
This is to keep the normal `tacd` relatively clean and keep the hacks contained to the `demo_mode`.

One of the new features is the simulation of voltage/current measurements in response to power on/off requests in the web ui.
See below for an example:

![dut_exp_dec](https://user-images.githubusercontent.com/1273320/223083617-5563c933-4b37-425a-82b6-cbf793cbeef2.png)
