### PR TITLE
Support LXA TAC Gen 2 devices (tacd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "log",
  "mqtt-protocol",
  "nix 0.26.2",
+ "numtoa",
  "png",
  "rand 0.8.5",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ industrial-io = { version = "0.5", default-features = false }
 log = { version = "0.4", features = ["release_max_level_warn"]}
 mqtt-protocol = "0.11"
 nix = "0.26"
+numtoa = "0.2.3"
 png = "0.17"
 rand = { version = "0.8", optional = true}
 serde_json = "1.0"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -276,7 +276,7 @@ paths:
             - tx
     get:
       summary: Check if the selected direction is activated
-      tags: [Input/Output]
+      tags: [Input/Output, UART]
       responses:
         '200':
           content:
@@ -286,7 +286,7 @@ paths:
 
     put:
       summary: Activate/Deactivate the direction
-      tags: [Input/Output]
+      tags: [Input/Output, UART]
       requestBody:
         content:
           application/json:
@@ -295,6 +295,31 @@ paths:
       responses:
         '204':
           description: The direction was enabled/disabled
+        '400':
+          description: The value could not be parsed as boolean
+
+  /v1/uart/powered:
+    get:
+      summary: Check if the power supply on the DUT UART connector is turned on
+      tags: [Input/Output, UART]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: boolean
+
+    put:
+      summary: Turn the power supply on the DUT UART connector on/off
+      tags: [Input/Output, UART]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: boolean
+      responses:
+        '204':
+          description: The UART supply was turned on/off
         '400':
           description: The value could not be parsed as boolean
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -78,6 +78,55 @@ paths:
         '400':
           description: The value could not be parsed into a boolean
 
+  /v1/tac/led/{led}/pattern:
+    parameters:
+      - name: led
+        description: The name of the respective LED
+        required: true
+        schema:
+          type: string
+          enum:
+            - out_0
+            - out_1
+            - dut_pwr
+            - eth_dut
+            - eth_lab
+            - status
+
+    get:
+      summary: Get the current blink pattern of the LED
+      tags: [User Interface]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlinkPattern'
+
+  /v1/tac/led/{led}/color:
+    parameters:
+      - name: led
+        description: The name of the respective LED
+        required: true
+        schema:
+          type: string
+          enum:
+            - status
+
+    get:
+      summary: Get the current RGB color of the LED
+      tags: [User Interface]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: number
+                minItems: 3
+                maxItems: 3
+
   /v1/dut/powered:
     get:
       summary: Get the current Power Switch state
@@ -671,6 +720,26 @@ components:
       oneOf:
         - required: [Press]
         - required: [Release]
+
+    BlinkPattern:
+      type: object
+      properties:
+        repetitions:
+          type: integer
+        steps:
+          type: array
+          items:
+            type: array
+            oneOf:
+              - type: number
+              - type: object
+                properties:
+                  secs:
+                    type: integer
+                  nanos:
+                    type: integer
+            minItems: 2
+            maxItems: 2
 
     DutPwrStatus:
       type: string

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -17,7 +17,8 @@
 
 use async_std::sync::Arc;
 
-use crate::broker::BrokerBuilder;
+use crate::broker::{BrokerBuilder, Topic};
+use crate::led::BlinkPattern;
 
 #[cfg(feature = "demo_mode")]
 mod zb {
@@ -71,7 +72,11 @@ pub struct DbusSession {
 }
 
 impl DbusSession {
-    pub async fn new(bb: &mut BrokerBuilder) -> Self {
+    pub async fn new(
+        bb: &mut BrokerBuilder,
+        led_dut: Arc<Topic<BlinkPattern>>,
+        led_uplink: Arc<Topic<BlinkPattern>>,
+    ) -> Self {
         let tacd = Tacd::new();
 
         let conn_builder = ConnectionBuilder::system()
@@ -82,7 +87,7 @@ impl DbusSession {
         let conn = Arc::new(tacd.serve(conn_builder).build().await.unwrap());
 
         Self {
-            network: Network::new(bb, &conn).await,
+            network: Network::new(bb, &conn, led_dut, led_uplink).await,
             rauc: Rauc::new(bb, &conn).await,
             systemd: Systemd::new(bb, &conn).await,
         }

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -46,7 +46,6 @@ pub struct DigitalIo {
     pub out_1: Arc<Topic<bool>>,
     pub uart_rx_en: Arc<Topic<bool>>,
     pub uart_tx_en: Arc<Topic<bool>>,
-    pub iobus_pwr_en: Arc<Topic<bool>>,
     pub iobus_flt_fb: Arc<Topic<bool>>,
 }
 
@@ -117,7 +116,6 @@ impl DigitalIo {
             out_1: handle_line_wo(bb, "/v1/output/out_1/asserted", "OUT_1", false, false),
             uart_rx_en: handle_line_wo(bb, "/v1/uart/rx/enabled", "UART_RX_EN", true, true),
             uart_tx_en: handle_line_wo(bb, "/v1/uart/tx/enabled", "UART_TX_EN", true, true),
-            iobus_pwr_en: handle_line_wo(bb, "/v1/iobus/powered", "IOBUS_PWR_EN", true, false),
             iobus_flt_fb: handle_line_ro(bb, "/v1/iobus/feedback/fault", "IOBUS_FLT_FB"),
         }
     }

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -19,6 +19,9 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::{block_on, spawn, spawn_blocking};
 
+use crate::broker::{BrokerBuilder, Topic};
+use crate::led::BlinkPattern;
+
 #[cfg(test)]
 mod gpio {
     mod test;
@@ -39,8 +42,6 @@ mod gpio {
 
 pub use gpio::{find_line, EventRequestFlags, EventType, LineHandle, LineRequestFlags};
 
-use crate::broker::{BrokerBuilder, Topic};
-
 pub struct DigitalIo {
     pub out_0: Arc<Topic<bool>>,
     pub out_1: Arc<Topic<bool>>,
@@ -57,6 +58,7 @@ fn handle_line_wo(
     line_name: &str,
     initial: bool,
     inverted: bool,
+    led_topic: Option<Arc<Topic<BlinkPattern>>>,
 ) -> Arc<Topic<bool>> {
     let topic = bb.topic_rw(path, Some(initial));
     let line = find_line(line_name).unwrap();
@@ -71,6 +73,11 @@ fn handle_line_wo(
 
         while let Some(ev) = src.next().await {
             dst.set_value((ev ^ inverted) as _).unwrap();
+
+            if let Some(led) = &led_topic {
+                let pattern = BlinkPattern::solid(if ev { 1.0 } else { 0.0 });
+                led.set(pattern).await;
+            }
         }
     });
 
@@ -110,13 +117,39 @@ fn handle_line_ro(bb: &mut BrokerBuilder, path: &str, line_name: &str) -> Arc<To
 }
 
 impl DigitalIo {
-    pub fn new(bb: &mut BrokerBuilder) -> Self {
+    pub fn new(
+        bb: &mut BrokerBuilder,
+        led_0: Arc<Topic<BlinkPattern>>,
+        led_1: Arc<Topic<BlinkPattern>>,
+    ) -> Self {
+        let out_0 = handle_line_wo(
+            bb,
+            "/v1/output/out_0/asserted",
+            "OUT_0",
+            false,
+            false,
+            Some(led_0),
+        );
+
+        let out_1 = handle_line_wo(
+            bb,
+            "/v1/output/out_1/asserted",
+            "OUT_1",
+            false,
+            false,
+            Some(led_1),
+        );
+
+        let uart_rx_en = handle_line_wo(bb, "/v1/uart/rx/enabled", "UART_RX_EN", true, true, None);
+        let uart_tx_en = handle_line_wo(bb, "/v1/uart/tx/enabled", "UART_TX_EN", true, true, None);
+        let iobus_flt_fb = handle_line_ro(bb, "/v1/iobus/feedback/fault", "IOBUS_FLT_FB");
+
         Self {
-            out_0: handle_line_wo(bb, "/v1/output/out_0/asserted", "OUT_0", false, false),
-            out_1: handle_line_wo(bb, "/v1/output/out_1/asserted", "OUT_1", false, false),
-            uart_rx_en: handle_line_wo(bb, "/v1/uart/rx/enabled", "UART_RX_EN", true, true),
-            uart_tx_en: handle_line_wo(bb, "/v1/uart/tx/enabled", "UART_TX_EN", true, true),
-            iobus_flt_fb: handle_line_ro(bb, "/v1/iobus/feedback/fault", "IOBUS_FLT_FB"),
+            out_0,
+            out_1,
+            uart_rx_en,
+            uart_tx_en,
+            iobus_flt_fb,
         }
     }
 }

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -47,7 +47,7 @@ impl LineHandle {
                     .set(val != 0);
                 iio_thread.get_channel("iobus-volt").unwrap().set(val != 0);
             }
-            "IO0" => {
+            "DUT_PWR_EN" => {
                 iio_thread
                     .clone()
                     .get_channel("pwr-curr")

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -285,13 +285,13 @@ impl DutPwrThread {
         pwr_volt: AdcChannel,
         pwr_curr: AdcChannel,
     ) -> Result<Self> {
-        let pwr_line = find_line("IO0").unwrap().request(
+        let pwr_line = find_line("DUT_PWR_EN").unwrap().request(
             LineRequestFlags::OUTPUT,
             1 - PWR_LINE_ASSERTED,
             "tacd",
         )?;
 
-        let discharge_line = find_line("IO1").unwrap().request(
+        let discharge_line = find_line("DUT_PWR_DISCH").unwrap().request(
             LineRequestFlags::OUTPUT,
             DISCHARGE_LINE_ASSERTED,
             "tacd",
@@ -538,8 +538,8 @@ mod tests {
 
     #[test]
     fn failsafe() {
-        let pwr_line = find_line("IO0").unwrap();
-        let discharge_line = find_line("IO1").unwrap();
+        let pwr_line = find_line("DUT_PWR_EN").unwrap();
+        let discharge_line = find_line("DUT_PWR_DISCH").unwrap();
 
         let (adc, dut_pwr) = {
             let mut bb = BrokerBuilder::new();

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,0 +1,134 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::io::ErrorKind;
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+use log::{error, info, warn};
+
+use crate::broker::{BrokerBuilder, Topic};
+
+mod demo_mode;
+mod extras;
+
+#[cfg(feature = "demo_mode")]
+use demo_mode::{Brightness, Leds, SysClass};
+
+#[cfg(not(feature = "demo_mode"))]
+use sysfs_class::{Brightness, Leds, SysClass};
+
+pub use extras::{BlinkPattern, BlinkPatternBuilder};
+use extras::{Pattern, RgbColor};
+
+pub struct Led {
+    pub out_0: Arc<Topic<BlinkPattern>>,
+    pub out_1: Arc<Topic<BlinkPattern>>,
+    pub dut_pwr: Arc<Topic<BlinkPattern>>,
+    pub eth_dut: Arc<Topic<BlinkPattern>>,
+    pub eth_lab: Arc<Topic<BlinkPattern>>,
+    pub status: Arc<Topic<BlinkPattern>>,
+    pub status_color: Arc<Topic<(f32, f32, f32)>>,
+}
+
+/// Get the specified LED and output an appropriate message if it fails
+///
+/// Different versions of the hardware have different amounts of on-board LEDs,
+/// so not finding an LED should not be a critical error.
+/// Just show a not and go on if an LED can not be set up.
+fn get_led_checked(hardware_name: &'static str) -> Option<Leds> {
+    match Leds::new(hardware_name) {
+        Ok(led) => Some(led),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            info!("Hardware does not have LED {hardware_name}, ignoring");
+            None
+        }
+        Err(err) => {
+            error!("Failed to set up LED {hardware_name}: {err}");
+            None
+        }
+    }
+}
+
+fn handle_pattern(
+    bb: &mut BrokerBuilder,
+    hardware_name: &'static str,
+    topic_name: &'static str,
+) -> Arc<Topic<BlinkPattern>> {
+    let topic = bb.topic_ro(&format!("/v1/tac/led/{topic_name}/pattern"), None);
+
+    if let Some(led) = get_led_checked(hardware_name) {
+        let topic_task = topic.clone();
+
+        spawn(async move {
+            let (mut rx, _) = topic_task.subscribe_unbounded().await;
+
+            while let Some(pattern) = rx.next().await {
+                if let Err(e) = led.set_pattern(pattern) {
+                    warn!("Failed to set LED pattern: {}", e);
+                }
+            }
+        });
+    }
+
+    topic
+}
+
+fn handle_color(
+    bb: &mut BrokerBuilder,
+    hardware_name: &'static str,
+    topic_name: &'static str,
+) -> Arc<Topic<(f32, f32, f32)>> {
+    let topic = bb.topic_ro(&format!("/v1/tac/led/{topic_name}/color"), None);
+
+    if let Some(led) = get_led_checked(hardware_name) {
+        let topic_task = topic.clone();
+
+        spawn(async move {
+            let (mut rx, _) = topic_task.subscribe_unbounded().await;
+
+            while let Some((r, g, b)) = rx.next().await {
+                let max = led.max_brightness().unwrap();
+
+                // I've encountered LEDs staying off when set to the max value,
+                // but setting them to (max - 1) turned them on.
+                let max = (max - 1) as f32;
+
+                if let Err(e) = led.set_rgb_color((r * max) as _, (g * max) as _, (b * max) as _) {
+                    warn!("Failed to set LED color: {}", e);
+                }
+            }
+        });
+    }
+
+    topic
+}
+
+impl Led {
+    pub fn new(bb: &mut BrokerBuilder) -> Self {
+        Self {
+            out_0: handle_pattern(bb, "tac:green:out0", "out_0"),
+            out_1: handle_pattern(bb, "tac:green:out1", "out_1"),
+            dut_pwr: handle_pattern(bb, "tac:green:dutpwr", "dut_pwr"),
+            eth_dut: handle_pattern(bb, "tac:green:statusdut", "eth_dut"),
+            eth_lab: handle_pattern(bb, "tac:green:statuslab", "eth_lab"),
+            status: handle_pattern(bb, "rgb:status", "status"),
+            status_color: handle_color(bb, "rgb:status", "status"),
+        }
+    }
+}

--- a/src/led/demo_mode.rs
+++ b/src/led/demo_mode.rs
@@ -1,0 +1,98 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::io::{Error, ErrorKind, Result};
+use std::path::{Path, PathBuf};
+use std::str::{from_utf8, FromStr};
+
+use sysfs_class::{set_trait_method, trait_method};
+
+const FILES_READ: &[(&str, &str)] = &[
+    ("tac:green:out0/max_brightness", "1"),
+    ("tac:green:out1/max_brightness", "1"),
+    ("tac:green:dutpwr/max_brightness", "1"),
+    ("rgb:status/max_brightness", "65535"),
+    ("rgb:status/multi_index", "red green blue"),
+];
+
+pub trait SysClass: Sized {
+    fn class() -> &'static str;
+    unsafe fn from_path_unchecked(path: PathBuf) -> Self;
+    fn path(&self) -> &Path;
+
+    fn new(id: &str) -> Result<Self> {
+        let inst = unsafe { Self::from_path_unchecked(id.into()) };
+        Ok(inst)
+    }
+
+    fn read_file<P: AsRef<Path>>(&self, name: P) -> Result<String> {
+        let path = self.path().join(name);
+        let path = path.to_str().unwrap();
+
+        FILES_READ
+            .iter()
+            .find(|(p, _)| p == &path)
+            .map(|(_, d)| d.to_string())
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, format!("{path} not found")))
+    }
+
+    fn parse_file<F: FromStr, P: AsRef<Path>>(&self, name: P) -> Result<F> {
+        self.read_file(name)?
+            .parse()
+            .map_err(|_| Error::new(ErrorKind::InvalidData, "too bad"))
+    }
+
+    fn write_file<P: AsRef<Path>, S: AsRef<[u8]>>(&self, name: P, data: S) -> Result<()> {
+        let path = self.path().join(name);
+        let path = path.to_str().unwrap();
+        let data = from_utf8(data.as_ref()).unwrap();
+
+        log::info!("LED: Write {} to {}", data, path);
+
+        Ok(())
+    }
+}
+
+pub trait Brightness {
+    fn brightness(&self) -> Result<u64>;
+    fn max_brightness(&self) -> Result<u64>;
+    fn set_brightness(&self, val: u64) -> Result<()>;
+}
+
+pub struct Leds {
+    path: PathBuf,
+}
+
+impl SysClass for Leds {
+    fn class() -> &'static str {
+        "leds"
+    }
+
+    unsafe fn from_path_unchecked(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Brightness for Leds {
+    trait_method!(brightness parse_file u64);
+    trait_method!(max_brightness parse_file u64);
+    set_trait_method!("brightness", set_brightness u64);
+}

--- a/src/led/extras.rs
+++ b/src/led/extras.rs
@@ -1,0 +1,144 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::io::Result;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Brightness, Leds, SysClass};
+
+// These are traits that could in theory be contributed upstream to the sysfs_class
+// crate, but the API is currently an ad-hoc creation.
+// Contribute this upstream once we have an API that we think makes sense.
+
+pub trait RgbColor: SysClass {
+    fn set_rgb_color(&self, r: u64, g: u64, b: u64) -> Result<()>;
+}
+
+impl RgbColor for Leds {
+    fn set_rgb_color(&self, r: u64, g: u64, b: u64) -> Result<()> {
+        let multi_intensity: String = self
+            .read_file("multi_index")?
+            .split_whitespace()
+            .map(|color_name| match color_name {
+                "red" => format!("{r} "),
+                "green" => format!("{g} "),
+                "blue" => format!("{b} "),
+                _ => panic!(),
+            })
+            .collect();
+
+        self.write_file("multi_intensity", multi_intensity)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct BlinkPattern {
+    repetitions: i32,
+    steps: Vec<(f32, Duration)>,
+}
+
+impl BlinkPattern {
+    #[allow(dead_code)]
+    pub fn solid(val: f32) -> Self {
+        Self {
+            repetitions: 1,
+            steps: vec![
+                (val, Duration::from_millis(1000)),
+                (val, Duration::from_millis(1000)),
+            ],
+        }
+    }
+}
+
+pub struct BlinkPatternBuilder {
+    #[allow(dead_code)]
+    value: f32,
+    pattern: BlinkPattern,
+}
+
+impl BlinkPatternBuilder {
+    #[allow(dead_code)]
+    pub fn new(initial: f32) -> Self {
+        Self {
+            value: initial,
+            pattern: BlinkPattern {
+                repetitions: 0,
+                steps: Vec::new(),
+            },
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn fade_to(mut self, brightness: f32, duration: Duration) -> Self {
+        self.value = brightness;
+        self.pattern.steps.push((brightness, duration));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn step_to(self, brightness: f32) -> Self {
+        self.fade_to(brightness, Duration::ZERO)
+    }
+
+    #[allow(dead_code)]
+    pub fn stay_for(self, duration: Duration) -> Self {
+        let value = self.value;
+        self.fade_to(value, duration)
+    }
+
+    #[allow(dead_code)]
+    pub fn repeat(mut self, repetitions: i32) -> BlinkPattern {
+        self.pattern.repetitions = repetitions;
+        self.pattern
+    }
+
+    #[allow(dead_code)]
+    pub fn once(self) -> BlinkPattern {
+        self.repeat(1)
+    }
+
+    #[allow(dead_code)]
+    pub fn forever(self) -> BlinkPattern {
+        self.repeat(-1)
+    }
+}
+
+pub trait Pattern: SysClass {
+    fn set_pattern(&self, pattern: BlinkPattern) -> Result<()>;
+}
+
+impl Pattern for Leds {
+    fn set_pattern(&self, pattern: BlinkPattern) -> Result<()> {
+        let max = self.max_brightness()? as f32;
+        let repetitions = pattern.repetitions;
+        let pattern: String = pattern
+            .steps
+            .iter()
+            .map(|(brightness, duration)| {
+                let brightness = (brightness * max).round();
+                let duration = duration.as_millis();
+                format!("{} {} ", brightness, duration)
+            })
+            .collect();
+
+        self.write_file("trigger", "pattern")?;
+        self.write_file("pattern", pattern)?;
+        self.write_file("repeat", repetitions.to_string())
+    }
+}

--- a/src/led/extras.rs
+++ b/src/led/extras.rs
@@ -54,7 +54,6 @@ pub struct BlinkPattern {
 }
 
 impl BlinkPattern {
-    #[allow(dead_code)]
     pub fn solid(val: f32) -> Self {
         Self {
             repetitions: 1,
@@ -67,13 +66,11 @@ impl BlinkPattern {
 }
 
 pub struct BlinkPatternBuilder {
-    #[allow(dead_code)]
     value: f32,
     pattern: BlinkPattern,
 }
 
 impl BlinkPatternBuilder {
-    #[allow(dead_code)]
     pub fn new(initial: f32) -> Self {
         Self {
             value: initial,
@@ -84,7 +81,6 @@ impl BlinkPatternBuilder {
         }
     }
 
-    #[allow(dead_code)]
     pub fn fade_to(mut self, brightness: f32, duration: Duration) -> Self {
         self.value = brightness;
         self.pattern.steps.push((brightness, duration));
@@ -96,13 +92,11 @@ impl BlinkPatternBuilder {
         self.fade_to(brightness, Duration::ZERO)
     }
 
-    #[allow(dead_code)]
     pub fn stay_for(self, duration: Duration) -> Self {
         let value = self.value;
         self.fade_to(value, duration)
     }
 
-    #[allow(dead_code)]
     pub fn repeat(mut self, repetitions: i32) -> BlinkPattern {
         self.pattern.repetitions = repetitions;
         self.pattern
@@ -113,7 +107,6 @@ impl BlinkPatternBuilder {
         self.repeat(1)
     }
 
-    #[allow(dead_code)]
     pub fn forever(self) -> BlinkPattern {
         self.repeat(-1)
     }

--- a/src/led/extras.rs
+++ b/src/led/extras.rs
@@ -63,6 +63,21 @@ impl BlinkPattern {
             ],
         }
     }
+
+    #[cfg(test)]
+    pub fn is_on(&self) -> bool {
+        self.steps.iter().all(|(brightness, _)| *brightness >= 0.5)
+    }
+
+    #[cfg(test)]
+    pub fn is_off(&self) -> bool {
+        self.steps.iter().all(|(brightness, _)| *brightness < 0.5)
+    }
+
+    #[cfg(test)]
+    pub fn is_blinking(&self) -> bool {
+        !(self.is_on() || self.is_off())
+    }
 }
 
 pub struct BlinkPatternBuilder {
@@ -87,7 +102,6 @@ impl BlinkPatternBuilder {
         self
     }
 
-    #[allow(dead_code)]
     pub fn step_to(self, brightness: f32) -> Self {
         self.fade_to(brightness, Duration::ZERO)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), std::io::Error> {
     let dut_pwr = DutPwrThread::new(&mut bb, adc.pwr_volt.clone(), adc.pwr_curr.clone())
         .await
         .unwrap();
-    let dig_io = DigitalIo::new(&mut bb);
+    let dig_io = DigitalIo::new(&mut bb, led.out_0.clone(), led.out_1.clone());
     let regulators = Regulators::new(&mut bb);
     let temperatures = Temperatures::new(&mut bb);
     let usb_hub = UsbHub::new(&mut bb);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), std::io::Error> {
     let mut bb = BrokerBuilder::new();
 
     // Expose hardware on the TAC via the broker framework.
-    let _led = Led::new(&mut bb);
+    let led = Led::new(&mut bb);
     let adc = Adc::new(&mut bb).await.unwrap();
     let dut_pwr = DutPwrThread::new(&mut bb, adc.pwr_volt.clone(), adc.pwr_curr.clone())
         .await
@@ -107,6 +107,7 @@ async fn main() -> Result<(), std::io::Error> {
             dig_io,
             dut_pwr,
             iobus,
+            led,
             regulators,
             system,
             temperatures,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,9 +61,14 @@ async fn main() -> Result<(), std::io::Error> {
     // Expose hardware on the TAC via the broker framework.
     let led = Led::new(&mut bb);
     let adc = Adc::new(&mut bb).await.unwrap();
-    let dut_pwr = DutPwrThread::new(&mut bb, adc.pwr_volt.clone(), adc.pwr_curr.clone())
-        .await
-        .unwrap();
+    let dut_pwr = DutPwrThread::new(
+        &mut bb,
+        adc.pwr_volt.clone(),
+        adc.pwr_curr.clone(),
+        led.dut_pwr.clone(),
+    )
+    .await
+    .unwrap();
     let dig_io = DigitalIo::new(&mut bb, led.out_0.clone(), led.out_1.clone());
     let regulators = Regulators::new(&mut bb);
     let temperatures = Temperatures::new(&mut bb);

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), std::io::Error> {
     // to them via HTTP / DBus APIs.
     let iobus = IoBus::new(&mut bb);
     let (network, rauc, systemd) = {
-        let dbus = DbusSession::new(&mut bb).await;
+        let dbus = DbusSession::new(&mut bb, led.eth_dut.clone(), led.eth_lab.clone()).await;
 
         (dbus.network, dbus.rauc, dbus.systemd)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod dut_power;
 mod http_server;
 mod iobus;
 mod journal;
+mod led;
 mod measurement;
 mod regulators;
 mod system;
@@ -40,6 +41,7 @@ use digital_io::DigitalIo;
 use dut_power::DutPwrThread;
 use http_server::HttpServer;
 use iobus::IoBus;
+use led::Led;
 use regulators::Regulators;
 use system::System;
 use temperatures::Temperatures;
@@ -57,6 +59,7 @@ async fn main() -> Result<(), std::io::Error> {
     let mut bb = BrokerBuilder::new();
 
     // Expose hardware on the TAC via the broker framework.
+    let _led = Led::new(&mut bb);
     let adc = Adc::new(&mut bb).await.unwrap();
     let dut_pwr = DutPwrThread::new(&mut bb, adc.pwr_volt.clone(), adc.pwr_curr.clone())
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod http_server;
 mod iobus;
 mod journal;
 mod measurement;
+mod regulators;
 mod system;
 mod temperatures;
 mod ui;
@@ -39,6 +40,7 @@ use digital_io::DigitalIo;
 use dut_power::DutPwrThread;
 use http_server::HttpServer;
 use iobus::IoBus;
+use regulators::Regulators;
 use system::System;
 use temperatures::Temperatures;
 use ui::{Ui, UiResources};
@@ -60,6 +62,7 @@ async fn main() -> Result<(), std::io::Error> {
         .await
         .unwrap();
     let dig_io = DigitalIo::new(&mut bb);
+    let regulators = Regulators::new(&mut bb);
     let temperatures = Temperatures::new(&mut bb);
     let usb_hub = UsbHub::new(&mut bb);
 
@@ -101,6 +104,7 @@ async fn main() -> Result<(), std::io::Error> {
             dig_io,
             dut_pwr,
             iobus,
+            regulators,
             system,
             temperatures,
             usb_hub,

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -1,0 +1,84 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+
+use crate::broker::{BrokerBuilder, Topic};
+
+#[cfg(feature = "demo_mode")]
+mod reg {
+    use std::io::Result;
+
+    pub fn regulator_set(name: &str, state: bool) -> Result<()> {
+        let state = if state { "enabled" } else { "disabled" };
+        println!("Regulator: would set {name} to {state} but don't feel like it");
+
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "demo_mode"))]
+mod reg {
+    use std::fs::write;
+    use std::io::Result;
+    use std::path::Path;
+
+    pub fn regulator_set(name: &str, state: bool) -> Result<()> {
+        let path = Path::new("/sys/devices/platform").join(name).join("state");
+        let state = if state { "enabled" } else { "disabled" };
+
+        write(path, state)
+    }
+}
+
+use reg::regulator_set;
+
+pub struct Regulators {
+    pub iobus_pwr_en: Arc<Topic<bool>>,
+    pub uart_pwr_en: Arc<Topic<bool>>,
+}
+
+fn handle_regulator(
+    bb: &mut BrokerBuilder,
+    path: &str,
+    regulator_name: &'static str,
+    initial: bool,
+) -> Arc<Topic<bool>> {
+    let topic = bb.topic_rw(path, Some(initial));
+    let topic_task = topic.clone();
+
+    spawn(async move {
+        let (mut src, _) = topic_task.subscribe_unbounded().await;
+
+        while let Some(ev) = src.next().await {
+            regulator_set(regulator_name, ev).unwrap();
+        }
+    });
+
+    topic
+}
+
+impl Regulators {
+    pub fn new(bb: &mut BrokerBuilder) -> Self {
+        Self {
+            iobus_pwr_en: handle_regulator(bb, "/v1/iobus/powered", "output_iobus_12v", true),
+            uart_pwr_en: handle_regulator(bb, "/v1/uart/powered", "output_vuart", true),
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -40,6 +40,7 @@ pub struct UiResources {
     pub iobus: crate::iobus::IoBus,
     pub network: crate::dbus::Network,
     pub rauc: crate::dbus::Rauc,
+    pub regulators: crate::regulators::Regulators,
     pub system: crate::system::System,
     pub systemd: crate::dbus::Systemd,
     pub temperatures: crate::temperatures::Temperatures,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,6 +23,7 @@ use async_std::task::{sleep, spawn};
 use tide::{Response, Server};
 
 use crate::broker::{BrokerBuilder, Topic};
+use crate::led::{BlinkPattern, BlinkPatternBuilder};
 
 mod buttons;
 mod draw_fb;
@@ -38,6 +39,7 @@ pub struct UiResources {
     pub dig_io: crate::digital_io::DigitalIo,
     pub dut_pwr: crate::dut_power::DutPwrThread,
     pub iobus: crate::iobus::IoBus,
+    pub led: crate::led::Led,
     pub network: crate::dbus::Network,
     pub rauc: crate::dbus::Rauc,
     pub regulators: crate::regulators::Regulators,
@@ -114,6 +116,35 @@ impl Ui {
                     Some(true) => {}
                     Some(false) => continue,
                     None => break,
+                }
+            }
+        });
+
+        // Blink the status LED when locator is active
+        let locator_task = locator.clone();
+        let led_status_pattern = res.led.status.clone();
+        let led_status_color = res.led.status_color.clone();
+        spawn(async move {
+            let (mut rx, _) = locator_task.subscribe_unbounded().await;
+
+            let pattern_locator_on = BlinkPatternBuilder::new(0.0)
+                .fade_to(1.0, Duration::from_millis(100))
+                .stay_for(Duration::from_millis(300))
+                .fade_to(0.0, Duration::from_millis(100))
+                .stay_for(Duration::from_millis(500))
+                .forever();
+
+            let pattern_locator_off = BlinkPattern::solid(1.0);
+
+            while let Some(ev) = rx.next().await {
+                if ev {
+                    // White blinking when locator is on
+                    led_status_color.set((1.0, 1.0, 1.0)).await;
+                    led_status_pattern.set(pattern_locator_on.clone()).await;
+                } else {
+                    // Green light when locator is off
+                    led_status_color.set((0.0, 1.0, 0.0)).await;
+                    led_status_pattern.set(pattern_locator_off.clone()).await;
                 }
             }
         });

--- a/src/ui/draw_fb.rs
+++ b/src/ui/draw_fb.rs
@@ -28,7 +28,7 @@ mod backend {
         pub device: (),
         pub var_screen_info: VarScreeninfo,
         pub fix_screen_info: FixScreeninfo,
-        pub frame: [u8; 128 * 64 * 2],
+        pub frame: [u8; 240 * 240 * 2],
     }
 
     impl Framebuffer {
@@ -37,15 +37,15 @@ mod backend {
                 device: (),
                 var_screen_info: VarScreeninfo {
                     bits_per_pixel: 16,
-                    xres: 128,
-                    yres: 64,
+                    xres: 240,
+                    yres: 240,
                     ..Default::default()
                 },
                 fix_screen_info: FixScreeninfo {
-                    line_length: 256,
+                    line_length: 480,
                     ..Default::default()
                 },
-                frame: [0; 128 * 64 * 2],
+                frame: [0; 240 * 240 * 2],
             })
         }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -18,7 +18,7 @@
 use async_std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use embedded_graphics::{
-    mono_font::{ascii::FONT_8X13, MonoTextStyle},
+    mono_font::MonoTextStyle,
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Line, PrimitiveStyle},
@@ -51,6 +51,7 @@ use super::widgets;
 use super::{FramebufferDrawTarget, Ui, UiResources};
 use crate::broker::{BrokerBuilder, Topic};
 use buttons::ButtonEvent;
+use widgets::UI_TEXT_FONT;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Copy)]
 pub enum Screen {
@@ -94,31 +95,31 @@ pub(super) trait MountableScreen: Sync + Send {
     async fn unmount(&mut self);
 }
 
-/// Draw static screen border contining a title and an indicator for the
+/// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
 async fn draw_border(text: &str, screen: Screen, draw_target: &Arc<Mutex<FramebufferDrawTarget>>) {
     let mut draw_target = draw_target.lock().await;
 
     Text::new(
         text,
-        Point::new(4, 13),
-        MonoTextStyle::new(&FONT_8X13, BinaryColor::On),
+        Point::new(8, 17),
+        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
     )
     .draw(&mut *draw_target)
     .unwrap();
 
-    Line::new(Point::new(0, 16), Point::new(118, 16))
+    Line::new(Point::new(0, 24), Point::new(230, 24))
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
         .draw(&mut *draw_target)
         .unwrap();
 
     let screen_idx = screen as i32;
     let num_screens = Screen::ScreenSaver as i32;
-    let x_start = screen_idx * 128 / num_screens;
-    let x_end = (screen_idx + 1) * 128 / num_screens;
+    let x_start = screen_idx * 240 / num_screens;
+    let x_end = (screen_idx + 1) * 240 / num_screens;
 
-    Line::new(Point::new(x_start, 62), Point::new(x_end, 62))
-        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
+    Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
         .draw(&mut *draw_target)
         .unwrap();
 }

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -63,14 +63,14 @@ impl MountableScreen for DigOutScreen {
             (
                 0,
                 "OUT 0",
-                29,
+                52,
                 &ui.res.dig_io.out_0,
                 &ui.res.adc.out0_volt.topic,
             ),
             (
                 1,
                 "OUT 1",
-                44,
+                72,
                 &ui.res.dig_io.out_1,
                 &ui.res.adc.out1_volt.topic,
             ),
@@ -81,7 +81,7 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -97,7 +97,7 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(54, y - 7),
+                    Point::new(100, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,
@@ -110,9 +110,9 @@ impl MountableScreen for DigOutScreen {
                 DynamicWidget::bar(
                     voltage.clone(),
                     ui.draw_target.clone(),
-                    Point::new(70, y - 6),
-                    45,
-                    7,
+                    Point::new(130, y - 14),
+                    90,
+                    18,
                     Box::new(|meas: &Measurement| meas.value.abs() / 5.0),
                 )
                 .await,

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -61,11 +61,11 @@ impl MountableScreen for IoBusScreen {
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-            Text::new("Power/Fault:", Point::new(0, 26), ui_text_style)
+            Text::new("Power/Fault:", Point::new(8, 52), ui_text_style)
                 .draw(&mut *draw_target)
                 .unwrap();
 
-            Text::new("Scan/CAN OK:", Point::new(0, 40), ui_text_style)
+            Text::new("Scan/CAN OK:", Point::new(8, 72), ui_text_style)
                 .draw(&mut *draw_target)
                 .unwrap();
         }
@@ -78,7 +78,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.dig_io.iobus_pwr_en.clone(),
                 ui.draw_target.clone(),
-                Point::new(80, 26 - 7),
+                Point::new(140, 52 - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
                     false => IndicatorState::Off,
@@ -91,7 +91,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.dig_io.iobus_flt_fb.clone(),
                 ui.draw_target.clone(),
-                Point::new(101, 26 - 7),
+                Point::new(170, 52 - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
                     false => IndicatorState::Off,
@@ -104,7 +104,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.iobus.server_info.clone(),
                 ui.draw_target.clone(),
-                Point::new(80, 40 - 7),
+                Point::new(140, 72 - 10),
                 Box::new(|info: &ServerInfo| match info.lss_state {
                     LSSState::Scanning => IndicatorState::On,
                     LSSState::Idle => IndicatorState::Off,
@@ -117,7 +117,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::indicator(
                 ui.res.iobus.server_info.clone(),
                 ui.draw_target.clone(),
-                Point::new(101, 40 - 7),
+                Point::new(170, 70 - 7),
                 Box::new(|info: &ServerInfo| match info.can_tx_error {
                     false => IndicatorState::On,
                     true => IndicatorState::Off,
@@ -130,7 +130,7 @@ impl MountableScreen for IoBusScreen {
             DynamicWidget::text(
                 ui.res.iobus.nodes.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 54),
+                Point::new(8, 92),
                 Box::new(move |nodes: &Nodes| format!("Nodes: {}", nodes.result.len())),
             )
             .await,

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -76,7 +76,7 @@ impl MountableScreen for IoBusScreen {
 
         self.widgets.push(Box::new(
             DynamicWidget::indicator(
-                ui.res.dig_io.iobus_pwr_en.clone(),
+                ui.res.regulators.iobus_pwr_en.clone(),
                 ui.draw_target.clone(),
                 Point::new(140, 52 - 10),
                 Box::new(|state: &bool| match *state {
@@ -137,7 +137,7 @@ impl MountableScreen for IoBusScreen {
         ));
 
         let (mut button_events, buttons_handle) = ui.buttons.clone().subscribe_unbounded().await;
-        let iobus_pwr_en = ui.res.dig_io.iobus_pwr_en.clone();
+        let iobus_pwr_en = ui.res.regulators.iobus_pwr_en.clone();
         let screen = ui.screen.clone();
 
         spawn(async move {

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -61,7 +61,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.adc.pwr_volt.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 26),
+                Point::new(8, 52),
                 Box::new(|meas: &Measurement| format!("V: {:-6.3}V", meas.value)),
             )
             .await,
@@ -71,9 +71,9 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::bar(
                 ui.res.adc.pwr_volt.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(70, 26 - 6),
-                45,
-                7,
+                Point::new(120, 52 - 14),
+                100,
+                18,
                 Box::new(|meas: &Measurement| meas.value / 48.0),
             )
             .await,
@@ -83,7 +83,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.adc.pwr_curr.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 36),
+                Point::new(8, 72),
                 Box::new(|meas: &Measurement| format!("I: {:-6.3}A", meas.value)),
             )
             .await,
@@ -93,9 +93,9 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::bar(
                 ui.res.adc.pwr_curr.topic.clone(),
                 ui.draw_target.clone(),
-                Point::new(70, 36 - 6),
-                45,
-                7,
+                Point::new(120, 72 - 14),
+                100,
+                18,
                 Box::new(|meas: &Measurement| meas.value / 48.0),
             )
             .await,
@@ -105,7 +105,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::text(
                 ui.res.dut_pwr.state.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 47),
+                Point::new(8, 92),
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => "On".into(),
                     OutputState::Off => "Off".into(),
@@ -124,7 +124,7 @@ impl MountableScreen for PowerScreen {
             DynamicWidget::indicator(
                 ui.res.dut_pwr.state.clone(),
                 ui.draw_target.clone(),
-                Point::new(90, 47 - 6),
+                Point::new(120, 92 - 10),
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => IndicatorState::On,
                     OutputState::Off | OutputState::OffFloating => IndicatorState::Off,

--- a/src/ui/screens/rauc.rs
+++ b/src/ui/screens/rauc.rs
@@ -77,7 +77,7 @@ impl MountableScreen for RaucScreen {
             DynamicWidget::text_center(
                 ui.res.rauc.progress.clone(),
                 ui.draw_target.clone(),
-                Point::new(64, 15),
+                Point::new(120, 100),
                 Box::new(|progress: &Progress| {
                     let (_, text) = progress.message.split_whitespace().fold(
                         (0, String::new()),
@@ -109,9 +109,9 @@ impl MountableScreen for RaucScreen {
             DynamicWidget::bar(
                 ui.res.rauc.progress.clone(),
                 ui.draw_target.clone(),
-                Point::new(14, 40),
-                100,
-                7,
+                Point::new(20, 180),
+                200,
+                18,
                 Box::new(|progress: &Progress| progress.percentage as f32 / 100.0),
             )
             .await,

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -50,7 +50,7 @@ fn rly(draw_target: &mut FramebufferDrawTarget) {
 
     Text::with_alignment(
         "Really reboot?\nLong press to confirm",
-        Point::new(64, 28),
+        Point::new(120, 120),
         text_style,
         Alignment::Center,
     )
@@ -65,7 +65,7 @@ fn brb(draw_target: &mut FramebufferDrawTarget) {
 
     Text::with_alignment(
         "Hold tight\nBe right back",
-        Point::new(64, 28),
+        Point::new(120, 120),
         text_style,
         Alignment::Center,
     )

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -26,7 +26,7 @@ use async_std::task::spawn;
 use async_trait::async_trait;
 
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X9, MonoFont, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoFont, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::Rectangle,
@@ -39,7 +39,7 @@ use super::{MountableScreen, Screen, Ui};
 
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
-const UI_TEXT_FONT: MonoFont = FONT_6X9;
+const UI_TEXT_FONT: MonoFont = FONT_10X20;
 const SCREEN_TYPE: Screen = Screen::ScreenSaver;
 const SCREENSAVER_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -142,7 +142,7 @@ impl MountableScreen for ScreenSaverScreen {
         let hostname = ui.res.network.hostname.get().await;
         let bounce = BounceAnimation::new(Rectangle::with_corners(
             Point::new(0, 8),
-            Point::new(118, 64),
+            Point::new(230, 240),
         ));
 
         self.widgets.push(Box::new(
@@ -159,6 +159,7 @@ impl MountableScreen for ScreenSaverScreen {
 
                     let text = Text::new(&hostname, Point::new(0, 0), ui_text_style);
                     let text = bounce.bounce(text);
+
                     text.draw(target).unwrap();
 
                     Some(text.bounding_box())

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -61,7 +61,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.temperatures.soc_temperature.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 26),
+                Point::new(8, 52),
                 Box::new(|meas: &Measurement| format!("SoC:    {:.0}C", meas.value)),
             )
             .await,
@@ -71,7 +71,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.network.uplink_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 36),
+                Point::new(8, 72),
                 Box::new(|info: &LinkInfo| match info.carrier {
                     true => format!("Uplink: {}MBit/s", info.speed),
                     false => "Uplink: Down".to_string(),
@@ -84,7 +84,7 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.network.dut_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 46),
+                Point::new(8, 92),
                 Box::new(|info: &LinkInfo| match info.carrier {
                     true => format!("DUT:    {}MBit/s", info.speed),
                     false => "DUT:    Down".to_string(),
@@ -97,10 +97,10 @@ impl MountableScreen for SystemScreen {
             DynamicWidget::text(
                 ui.res.network.bridge_interface.clone(),
                 ui.draw_target.clone(),
-                Point::new(0, 56),
+                Point::new(8, 112),
                 Box::new(|ips: &Vec<String>| {
                     let ip = ips.get(0).map(|s| s.as_str()).unwrap_or("-");
-                    format!("IP: {}", ip)
+                    format!("IP:     {}", ip)
                 }),
             )
             .await,

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -60,8 +60,8 @@ impl MountableScreen for UartScreen {
         ));
 
         let ports = [
-            (0, "UART RX EN", 29, &ui.res.dig_io.uart_rx_en),
-            (1, "UART TX EN", 44, &ui.res.dig_io.uart_tx_en),
+            (0, "UART RX EN", 52, &ui.res.dig_io.uart_rx_en),
+            (1, "UART TX EN", 72, &ui.res.dig_io.uart_tx_en),
         ];
 
         for (idx, name, y, status) in ports {
@@ -69,7 +69,7 @@ impl MountableScreen for UartScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -85,7 +85,7 @@ impl MountableScreen for UartScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(80, y - 7),
+                    Point::new(160, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -63,21 +63,21 @@ impl MountableScreen for UsbScreen {
             (
                 0,
                 "Port 1",
-                28,
+                52,
                 &ui.res.usb_hub.port1.powered,
                 &ui.res.adc.usb_host1_curr.topic,
             ),
             (
                 1,
                 "Port 2",
-                41,
+                72,
                 &ui.res.usb_hub.port2.powered,
                 &ui.res.adc.usb_host2_curr.topic,
             ),
             (
                 2,
                 "Port 3",
-                54,
+                92,
                 &ui.res.usb_hub.port3.powered,
                 &ui.res.adc.usb_host3_curr.topic,
             ),
@@ -88,7 +88,7 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::text(
                     self.highlighted.clone(),
                     ui.draw_target.clone(),
-                    Point::new(0, y),
+                    Point::new(8, y),
                     Box::new(move |highlight: &u8| {
                         format!(
                             "{} {}",
@@ -104,7 +104,7 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::indicator(
                     status.clone(),
                     ui.draw_target.clone(),
-                    Point::new(54, y - 7),
+                    Point::new(100, y - 10),
                     Box::new(|state: &bool| match *state {
                         true => IndicatorState::On,
                         false => IndicatorState::Off,
@@ -117,9 +117,9 @@ impl MountableScreen for UsbScreen {
                 DynamicWidget::bar(
                     current.clone(),
                     ui.draw_target.clone(),
-                    Point::new(70, y - 6),
-                    45,
-                    7,
+                    Point::new(130, y - 14),
+                    90,
+                    18,
                     Box::new(|meas: &Measurement| meas.value / 0.5),
                 )
                 .await,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -20,7 +20,9 @@ use async_std::sync::Arc;
 use async_std::task::spawn;
 use async_trait::async_trait;
 
-use embedded_graphics::prelude::*;
+use embedded_graphics::{
+    mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
+};
 
 use super::buttons::*;
 use super::widgets::*;
@@ -29,6 +31,8 @@ use crate::broker::{BrokerBuilder, Native, SubscriptionHandle, Topic};
 use crate::measurement::Measurement;
 
 const SCREEN_TYPE: Screen = Screen::Usb;
+const CURRENT_LIMIT_PER_PORT: f32 = 0.5;
+const CURRENT_LIMIT_TOTAL: f32 = 0.7;
 
 pub struct UsbScreen {
     highlighted: Arc<Topic<u8>>,
@@ -63,26 +67,48 @@ impl MountableScreen for UsbScreen {
             (
                 0,
                 "Port 1",
-                52,
+                92,
                 &ui.res.usb_hub.port1.powered,
                 &ui.res.adc.usb_host1_curr.topic,
             ),
             (
                 1,
                 "Port 2",
-                72,
+                112,
                 &ui.res.usb_hub.port2.powered,
                 &ui.res.adc.usb_host2_curr.topic,
             ),
             (
                 2,
                 "Port 3",
-                92,
+                132,
                 &ui.res.usb_hub.port3.powered,
                 &ui.res.adc.usb_host3_curr.topic,
             ),
         ];
 
+        {
+            let mut draw_target = ui.draw_target.lock().await;
+
+            let ui_text_style: MonoTextStyle<BinaryColor> =
+                MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+            Text::new("Total", Point::new(8, 52), ui_text_style)
+                .draw(&mut *draw_target)
+                .unwrap();
+        }
+
+        self.widgets.push(Box::new(
+            DynamicWidget::bar(
+                ui.res.adc.usb_host_curr.topic.clone(),
+                ui.draw_target.clone(),
+                Point::new(130, 52 - 14),
+                90,
+                18,
+                Box::new(|meas: &Measurement| meas.value / CURRENT_LIMIT_TOTAL),
+            )
+            .await,
+        ));
         for (idx, name, y, status, current) in ports {
             self.widgets.push(Box::new(
                 DynamicWidget::text(
@@ -120,7 +146,7 @@ impl MountableScreen for UsbScreen {
                     Point::new(130, y - 14),
                     90,
                     18,
-                    Box::new(|meas: &Measurement| meas.value / 0.5),
+                    Box::new(|meas: &Measurement| meas.value / CURRENT_LIMIT_PER_PORT),
                 )
                 .await,
             ));

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -20,7 +20,7 @@ use async_std::sync::{Arc, Mutex};
 use async_std::task::{spawn, JoinHandle};
 use async_trait::async_trait;
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X9, MonoFont, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoFont, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Circle, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
@@ -32,7 +32,7 @@ use serde::Serialize;
 use super::FramebufferDrawTarget;
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
-pub const UI_TEXT_FONT: MonoFont = FONT_6X9; // FIXME: Use font 6x8?
+pub const UI_TEXT_FONT: MonoFont = FONT_10X20;
 
 pub enum IndicatorState {
     On,
@@ -267,11 +267,13 @@ impl DynamicWidget<i32> {
             topic,
             target,
             Box::new(move |val, target| {
-                let size = 64 - ((*val - 32).abs() * 2);
+                let size = 128 - (*val - 32).abs() * 4;
 
                 if size != 0 {
-                    let bounding =
-                        Rectangle::with_center(Point::new(128 - 5, 32), Size::new(10, size as u32));
+                    let bounding = Rectangle::with_center(
+                        Point::new(240 - 5, 120),
+                        Size::new(10, size as u32),
+                    );
 
                     bounding
                         .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))


### PR DESCRIPTION
Hardware generations
-----------------------------

There is a new batch of LXA TAC devices with a slightly different set of hardware features (**Gen 2**).
Here is an overview of the current hardware generations:

- **Gen 1 Stock**
  - 128px x 64px OLED screen
  - No LED indicators on the top side of the device.
- **Gen 1 LCD**
  - Like **Gen 1 Stock** but retrofitted with a 240px x 240px LCD screen
  - All of the **Gen 1 Stock** devices should be modified to this state
- **Gen 2**
  - 240px x 240px LCD screen
  - LED indicators on the top side of the device

With this PR applied only hardware generations **Gen 1 LCD** and **Gen 2** are supported. Support for **Gen 1 Stock** is dropped.

Related pull requests
----------------------------

- `tacd` This PR was modified to be built upon the mega cleanup PR #16, which should thus be merged first.
- `meta-lxatac` There are some changes that have to happen in tandem with changes in `meta-lxatac`, which are tracked in linux-automation/meta-lxatac#33.
  - [x] Make sure the switch to userspace regulator consumers happens in the devicetree
  - [ ] Make sure the correct `tacd` upstream URL and revision is used in the `tacd` and `tacd-webui` recipes
  - [x] Make sure the change to the DUT Power GPIO line names happens in the devicetree
  - [x] Make sure the LED names in the Gen 2 devicetree match what is written here.

Other open tasks
-----------------------

- [x] Decide how the RGB status LED on Gen 2 devices should behave (e.g. if and how it should blink in response to the locator state) and implement that.
  20230320 lgo: The Locator LED blinks white when active and shows solid green when inactive. The color should also change depending on error cases. This is not yet implemented, as the lowest hanging error case (DUT Power turned off) was better indicated by the DUT Power LED blinking.