### PR TITLE
ci: tacd: run apt update before apt install

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1
         with:
@@ -46,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1
         with:
@@ -73,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Our jobs currently fail because the package list is stale:

    After this operation, 1433 kB of additional disk space will be used.
    Get:1 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libiio0…
    Get:2 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libiio…
    Err:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64…
      404  Not Found [IP: 40.119.46.219 80]

Update the package list before running apt install.