### PR TITLE
Poll for RAUC updates and show notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ png = "0.17"
 rand = { version = "0.8", optional = true}
 serde_json = "1.0"
 serde_repr = "0.1"
+serde_yaml = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 sha-1 = "0.10"
 surf = { version = "2.3", default-features = false, features = ["h1-client-no-tls"] }

--- a/demo_files/srv/tacd/state.json
+++ b/demo_files/srv/tacd/state.json
@@ -1,6 +1,7 @@
 {
   "format_version": 1,
   "persistent_topics": {
+    "/v1/tac/display/show_help": false,
     "/v1/tac/setup_mode": false
   }
 }

--- a/demo_files/usr/share/tacd/update_channels/01_stable.yaml
+++ b/demo_files/usr/share/tacd/update_channels/01_stable.yaml
@@ -1,0 +1,8 @@
+name: stable
+display_name: Stable
+description: |
+  Official updates bundles provided by the Linux Automation GmbH.
+  The released bundles are manually tested and signed before publication.
+url: |
+  https://downloads.linux-automation.com/lxatac/software/stable/latest/lxatac-core-bundle-base-lxatac.raucb
+polling_interval: "4d"

--- a/demo_files/usr/share/tacd/update_channels/05_testing.yaml
+++ b/demo_files/usr/share/tacd/update_channels/05_testing.yaml
@@ -1,0 +1,9 @@
+name: testing
+display_name: Testing
+description: |
+  Testing bundles provided by the Linux Automation GmbH.
+  The released bundles are automatically tested on actual hardware and automatically uploaded.
+  Receives more frequent but less stable updates than the Stable channel.
+url: |
+  https://downloads.linux-automation.com/lxatac/software/testing/latest/lxatac-core-bundle-base-lxatac.raucb
+polling_interval: "24h"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -30,6 +30,17 @@ paths:
         '400':
           description: The value could not be parsed into a screen name
 
+  /v1/tac/display/alerts:
+    get:
+      summary: A list of currently pending alerts shown on the local UI
+      tags: [User Interface]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Alerts'
+
   /v1/tac/display/buttons:
     put:
       summary: Simulate a button press/release on the device
@@ -77,6 +88,30 @@ paths:
           description: The locator status was set sucessfully
         '400':
           description: The value could not be parsed into a boolean
+
+  /v1/tac/display/show_help:
+    get:
+      summary: Display a help menu on the local screen
+      tags: [User Interface]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: boolean
+    put:
+      summary: Display a help menu on the local screen
+      tags: [User Interface]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: boolean
+      responses:
+        '204':
+          description: Help will be shown or hidden as requested
+        '400':
+          description: The request could not be parsed as boolean
 
   /v1/tac/led/{led}/pattern:
     parameters:
@@ -772,10 +807,19 @@ components:
         - System
         - IoBus
         - Uart
-        - ScreenSaver
-        - Breakout
-        - RebootConfirm
-        - Rauc
+
+    Alerts:
+      type: array
+      items:
+        type: string
+        enum:
+          - ScreenSaver
+          - Locator
+          - RebootConfirm
+          - UpdateAvailable
+          - UpdateInstallation
+          - Help
+          - Setup
 
     ButtonEvent:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -824,30 +824,23 @@ components:
     ButtonEvent:
       type: object
       properties:
-        Press:
-          type: object
-          properties:
-            btn:
-              type: string
-              enum:
-                - Upper
-                - Lower
-        Release:
-          type: object
-          properties:
-            btn:
-              type: string
-              enum:
-                - Upper
-                - Lower
-            dur:
-              type: string
-              enum:
-                - Short
-                - Long
-      oneOf:
-        - required: [Press]
-        - required: [Release]
+        type: object
+        properties:
+          dir:
+            type: string
+            enum:
+              - Press
+              - Release
+          btn:
+            type: string
+            enum:
+              - Upper
+              - Lower
+          dur:
+            type: string
+            enum:
+              - Short
+              - Long
 
     BlinkPattern:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -747,6 +747,43 @@ paths:
         '400':
           description: The value could not be parsed as string
 
+  /v1/tac/update/channels:
+    get:
+      summary: Get a list of update channels and available updates
+      tags: [Updating]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateChannels'
+
+  /v1/tac/update/channels/reload:
+    put:
+      summary: Request an update of the channels list and update availability
+      tags: [Updating]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: boolean
+      responses:
+        '204':
+          description: An update was requested (if true was sent)
+        '400':
+          description: The value could not be parsed as boolean
+
+  /v1/tac/update/should_reboot:
+    get:
+      summary: Should the system be rebooted as there is a new bundle in the other slot?
+      tags: [Updating]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: boolean
+
   /v1/tac/network/hostname:
     get:
       summary: Get the systems hostname
@@ -969,6 +1006,38 @@ components:
           type: string
         nesting_depth:
           type: number
+
+    UpdateChannels:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          display_name:
+            type: string
+          description:
+            type: string
+          url:
+            type: string
+          polling_interval:
+            type: object
+            properties:
+              secs:
+                type: integer
+              nanos:
+                type: integer
+          enabled:
+            type: boolean
+          bundle:
+            type: object
+            properties:
+              compatible:
+                type: string
+              version:
+                type: string,
+              newer_than_installed:
+                type: boolean
 
     ServiceStatus:
       type: object

--- a/src/broker/topic.rs
+++ b/src/broker/topic.rs
@@ -325,6 +325,19 @@ impl<E: Serialize + DeserializeOwned + Clone> Topic<E> {
     }
 }
 
+impl<E: Serialize + DeserializeOwned + Clone + PartialEq> Topic<E> {
+    /// Set a new value for the topic and notify subscribers _if the value changed_
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - Value to set the topic to
+    pub fn set_if_changed(&self, msg: E) {
+        let msg = Some(msg);
+
+        self.modify(|prev| if prev != msg { msg } else { None });
+    }
+}
+
 impl<E: Serialize + DeserializeOwned + Clone + Not + Not<Output = E>> Topic<E> {
     /// Toggle the value of a topic
     ///

--- a/src/broker/topic.rs
+++ b/src/broker/topic.rs
@@ -17,6 +17,7 @@
 
 use std::collections::VecDeque;
 use std::marker::PhantomData;
+use std::ops::Not;
 use std::sync::{Arc, Mutex, Weak};
 
 use async_std::channel::{unbounded, Receiver, Sender, TrySendError};
@@ -321,6 +322,17 @@ impl<E: Serialize + DeserializeOwned + Clone> Topic<E> {
     pub fn subscribe_unbounded(self: Arc<Self>) -> (Receiver<E>, SubscriptionHandle<E, Native>) {
         let (tx, rx) = unbounded();
         (rx, self.subscribe(tx))
+    }
+}
+
+impl<E: Serialize + DeserializeOwned + Clone + Not + Not<Output = E>> Topic<E> {
+    /// Toggle the value of a topic
+    ///
+    /// # Arguments
+    ///
+    /// * `default` - The value to assume if none was set yet
+    pub fn toggle(&self, default: E) {
+        self.modify(|prev| Some(!prev.unwrap_or(default)));
     }
 }
 

--- a/src/dbus/rauc/mod.rs
+++ b/src/dbus/rauc/mod.rs
@@ -15,25 +15,66 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
+use async_std::channel::Receiver;
+use async_std::stream::StreamExt;
 use async_std::sync::Arc;
+use async_std::task::{sleep, spawn, JoinHandle};
+use log::warn;
 use serde::{Deserialize, Serialize};
-
-#[cfg(not(feature = "demo_mode"))]
-use async_std::prelude::*;
-
-#[cfg(not(feature = "demo_mode"))]
-use async_std::task::spawn;
 
 use super::Connection;
 use crate::broker::{BrokerBuilder, Topic};
+
+mod update_channels;
+pub use update_channels::Channel;
 
 #[cfg(feature = "demo_mode")]
 mod demo_mode;
 
 #[cfg(not(feature = "demo_mode"))]
 mod installer;
+
+#[cfg(not(feature = "demo_mode"))]
+use installer::InstallerProxy;
+
+#[cfg(feature = "demo_mode")]
+mod imports {
+    pub struct InstallerProxy<'a> {
+        _dummy: &'a (),
+    }
+
+    impl<'a> InstallerProxy<'a> {
+        pub async fn new<C>(_conn: C) -> Option<InstallerProxy<'a>> {
+            Some(Self { _dummy: &() })
+        }
+
+        pub async fn info(&self, _url: &str) -> anyhow::Result<(String, String)> {
+            let compatible = "LXA TAC".to_string();
+            let version = "4.0-0-20230428214619".to_string();
+
+            Ok((compatible, version))
+        }
+    }
+
+    pub const CHANNELS_DIR: &str = "demo_files/usr/share/tacd/update_channels";
+}
+
+#[cfg(not(feature = "demo_mode"))]
+mod imports {
+    pub use anyhow::{anyhow, bail, Result};
+    pub use futures::{select, FutureExt};
+    pub use log::{error, info};
+
+    pub const CHANNELS_DIR: &str = "/usr/share/tacd/update_channels";
+}
+
+const RELOAD_RATE_LIMIT: Duration = Duration::from_secs(10 * 60);
+
+use imports::*;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Progress {
@@ -60,6 +101,163 @@ pub struct Rauc {
     pub slot_status: Arc<Topic<Arc<SlotStatus>>>,
     pub last_error: Arc<Topic<String>>,
     pub install: Arc<Topic<String>>,
+    pub channels: Arc<Topic<Vec<Channel>>>,
+    pub reload: Arc<Topic<bool>>,
+    pub should_reboot: Arc<Topic<bool>>,
+}
+
+fn compare_versions(v1: &str, v2: &str) -> Option<Ordering> {
+    // Version strings look something like this: "4.0-0-20230428214619"
+    // Use string sorting on the date part to determine which bundle is newer.
+    let date_1 = v1.rsplit_once('-').map(|(_, d)| d);
+    let date_2 = v2.rsplit_once('-').map(|(_, d)| d);
+
+    // Return Sone if either version could not be split or a Some with the
+    // ordering between the dates.
+    date_1.zip(date_2).map(|(d1, d2)| d1.cmp(d2))
+}
+
+#[cfg(not(feature = "demo_mode"))]
+fn booted_older_than_other(slot_status: &SlotStatus) -> Result<bool> {
+    let rootfs_0 = slot_status.get("rootfs_0");
+    let rootfs_1 = slot_status.get("rootfs_1");
+
+    let rootfs_0_booted = rootfs_0.and_then(|r| r.get("state")).map(|s| s == "booted");
+    let rootfs_1_booted = rootfs_1.and_then(|r| r.get("state")).map(|s| s == "booted");
+
+    let (booted, other) = match (rootfs_0_booted, rootfs_1_booted) {
+        (Some(true), Some(true)) => {
+            bail!("Two booted RAUC slots at the same time");
+        }
+        (Some(true), _) => (rootfs_0, rootfs_1),
+        (_, Some(true)) => (rootfs_1, rootfs_0),
+        _ => {
+            bail!("No booted RAUC slot");
+        }
+    };
+
+    // Not having version information for the booted slot is an error.
+    let booted_version = booted
+        .and_then(|r| r.get("bundle_version"))
+        .ok_or(anyhow!("No bundle version information for booted slot"))?;
+
+    // Not having version information for the other slot just means that
+    // it is not newer.
+    if let Some(other_version) = other.and_then(|r| r.get("bundle_version")) {
+        if let Some(rel) = compare_versions(other_version, booted_version) {
+            Ok(rel.is_gt())
+        } else {
+            Err(anyhow!(
+                "Failed to compare date for bundle versions \"{}\" and \"{}\"",
+                other_version,
+                booted_version
+            ))
+        }
+    } else {
+        Ok(false)
+    }
+}
+
+async fn channel_polling_task(
+    conn: Arc<Connection>,
+    channels: Arc<Topic<Vec<Channel>>>,
+    slot_status: Arc<Topic<Arc<SlotStatus>>>,
+    name: String,
+) {
+    let proxy = InstallerProxy::new(&conn).await.unwrap();
+
+    while let Some(mut channel) = channels
+        .try_get()
+        .and_then(|chs| chs.into_iter().find(|ch| ch.name == name))
+    {
+        let polling_interval = channel.polling_interval;
+        let slot_status = slot_status.try_get();
+
+        if let Err(e) = channel.poll(&proxy, slot_status.as_deref()).await {
+            warn!(
+                "Failed to fetch update for update channel \"{}\": {}",
+                channel.name, e
+            );
+        }
+
+        channels.modify(|chs| {
+            let mut chs = chs?;
+            let channel_prev = chs.iter_mut().find(|ch| ch.name == name)?;
+
+            // Check if the bundle we polled is the same as before and we don't need
+            // to send a message to the subscribers.
+            if *channel_prev == channel {
+                return None;
+            }
+
+            // Update the channel description with the newly polled bundle info
+            *channel_prev = channel;
+
+            Some(chs)
+        });
+
+        match polling_interval {
+            Some(pi) => sleep(pi).await,
+            None => break,
+        }
+    }
+}
+
+async fn channel_list_update_task(
+    conn: Arc<Connection>,
+    mut reload_stream: Receiver<bool>,
+    channels: Arc<Topic<Vec<Channel>>>,
+    slot_status: Arc<Topic<Arc<SlotStatus>>>,
+) {
+    let mut previous: Option<Instant> = None;
+    let mut polling_tasks: Vec<JoinHandle<_>> = Vec::new();
+
+    while let Some(reload) = reload_stream.next().await {
+        if !reload {
+            continue;
+        }
+
+        // Polling for updates is a somewhat expensive operation.
+        // Make sure it can not be abused to DOS the tacd.
+        if previous
+            .map(|p| p.elapsed() < RELOAD_RATE_LIMIT)
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        // Read the list of available update channels
+        let new_channels = match Channel::from_directory(CHANNELS_DIR) {
+            Ok(chs) => chs,
+            Err(e) => {
+                warn!("Failed to get list of update channels: {e}");
+                continue;
+            }
+        };
+
+        // Stop the currently running polling tasks
+        for task in polling_tasks.drain(..) {
+            task.cancel().await;
+        }
+
+        let names: Vec<String> = new_channels.iter().map(|c| c.name.clone()).collect();
+
+        channels.set(new_channels);
+
+        // Spawn new polling tasks. They will poll once immediately.
+        for name in names.into_iter() {
+            let polling_task = spawn(channel_polling_task(
+                conn.clone(),
+                channels.clone(),
+                slot_status.clone(),
+                name,
+            ));
+
+            polling_tasks.push(polling_task);
+        }
+
+        previous = Some(Instant::now());
+    }
 }
 
 impl Rauc {
@@ -70,6 +268,9 @@ impl Rauc {
             slot_status: bb.topic_ro("/v1/tac/update/slots", None),
             last_error: bb.topic_ro("/v1/tac/update/last_error", None),
             install: bb.topic_wo("/v1/tac/update/install", Some("".to_string())),
+            channels: bb.topic_ro("/v1/tac/update/channels", None),
+            reload: bb.topic_wo("/v1/tac/update/channels/reload", Some(true)),
+            should_reboot: bb.topic_ro("/v1/tac/update/should_reboot", Some(false)),
         }
     }
 
@@ -81,6 +282,15 @@ impl Rauc {
         inst.slot_status.set(Arc::new(demo_mode::slot_status()));
         inst.last_error.set("".to_string());
 
+        // Reload the channel list on request
+        let (reload_stream, _) = inst.reload.clone().subscribe_unbounded();
+        spawn(channel_list_update_task(
+            Arc::new(Connection),
+            reload_stream,
+            inst.channels.clone(),
+            inst.slot_status.clone(),
+        ));
+
         inst
     }
 
@@ -91,9 +301,11 @@ impl Rauc {
         let conn_task = conn.clone();
         let operation = inst.operation.clone();
         let slot_status = inst.slot_status.clone();
+        let channels = inst.channels.clone();
+        let should_reboot = inst.should_reboot.clone();
 
         spawn(async move {
-            let proxy = installer::InstallerProxy::new(&conn_task).await.unwrap();
+            let proxy = InstallerProxy::new(&conn_task).await.unwrap();
 
             let mut stream = proxy.receive_operation_changed().await;
 
@@ -143,6 +355,30 @@ impl Rauc {
                         })
                         .collect();
 
+                    // Update the `newer_than_installed` field for the upstream bundles inside
+                    // of the update channels.
+                    channels.modify(|prev| {
+                        let prev = prev?;
+
+                        let mut new = prev.clone();
+
+                        for ch in new.iter_mut() {
+                            if let Some(bundle) = ch.bundle.as_mut() {
+                                bundle.update_install(&slots);
+                            }
+                        }
+
+                        // Only send out messages if anything changed
+                        (new != prev).then_some(new)
+                    });
+
+                    // Provide a simple yes/no "should reboot into other slot?" information
+                    // based on the bundle versions in the booted slot and the other slot.
+                    match booted_older_than_other(&slots) {
+                        Ok(b) => should_reboot.set_if_changed(b),
+                        Err(e) => warn!("Could not determine if TAC should be rebooted: {e}"),
+                    }
+
                     // In the RAUC API the slot status is a list of (name, info) tuples.
                     // It is once again easier in typescript to represent it as a dict with
                     // the names as keys, so that is what's exposed here.
@@ -165,7 +401,7 @@ impl Rauc {
 
         // Forward the "progress" property to the broker framework
         spawn(async move {
-            let proxy = installer::InstallerProxy::new(&conn_task).await.unwrap();
+            let proxy = InstallerProxy::new(&conn_task).await.unwrap();
 
             let mut stream = proxy.receive_progress_changed().await;
 
@@ -185,7 +421,7 @@ impl Rauc {
 
         // Forward the "last_error" property to the broker framework
         spawn(async move {
-            let proxy = installer::InstallerProxy::new(&conn_task).await.unwrap();
+            let proxy = InstallerProxy::new(&conn_task).await.unwrap();
 
             let mut stream = proxy.receive_last_error_changed().await;
 
@@ -205,17 +441,27 @@ impl Rauc {
 
         // Forward the "install" topic from the broker framework to RAUC
         spawn(async move {
-            let proxy = installer::InstallerProxy::new(&conn_task).await.unwrap();
+            let proxy = InstallerProxy::new(&conn_task).await.unwrap();
 
             while let Some(url) = install_stream.next().await {
                 // Poor-mans validation. It feels wrong to let someone point to any
                 // file on the TAC from the web interface.
                 if url.starts_with("http://") || url.starts_with("https://") {
-                    // TODO: some kind of error handling
-                    let _ = proxy.install(&url).await;
+                    if let Err(e) = proxy.install(&url).await {
+                        error!("Failed to install bundle: {}", e);
+                    }
                 }
             }
         });
+
+        // Reload the channel list on request
+        let (reload_stream, _) = inst.reload.clone().subscribe_unbounded();
+        spawn(channel_list_update_task(
+            conn.clone(),
+            reload_stream,
+            inst.channels.clone(),
+            inst.slot_status.clone(),
+        ));
 
         inst
     }

--- a/src/dbus/rauc/update_channels.rs
+++ b/src/dbus/rauc/update_channels.rs
@@ -1,0 +1,209 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::fs::{read_dir, read_to_string, DirEntry};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use serde::{Deserialize, Serialize};
+
+use super::{compare_versions, InstallerProxy, SlotStatus};
+
+#[cfg(feature = "demo_mode")]
+const ENABLE_DIR: &str = "demo_files/etc/rauc/certificates-enabled";
+
+#[cfg(not(feature = "demo_mode"))]
+const ENABLE_DIR: &str = "/etc/rauc/certificates-enabled";
+
+const ONE_MINUTE: Duration = Duration::from_secs(60);
+const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
+const ONE_DAY: Duration = Duration::from_secs(24 * 60 * 60);
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+pub struct UpstreamBundle {
+    pub compatible: String,
+    pub version: String,
+    pub newer_than_installed: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+pub struct Channel {
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub url: String,
+    pub polling_interval: Option<Duration>,
+    pub enabled: bool,
+    pub bundle: Option<UpstreamBundle>,
+}
+
+#[derive(Deserialize)]
+pub struct ChannelFile {
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub url: String,
+    pub polling_interval: Option<String>,
+}
+
+impl Channel {
+    fn from_file(path: &Path) -> Result<Self> {
+        let file_name = || {
+            path.file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or("<no filename>")
+        };
+
+        let mut channel_file: ChannelFile = {
+            let content = read_to_string(path)?;
+            serde_yaml::from_str(&content)?
+        };
+
+        let polling_interval = match channel_file.polling_interval.take() {
+            Some(mut pi) => {
+                let multiplier = match pi.pop() {
+                    Some('m') => ONE_MINUTE,
+                    Some('h') => ONE_HOUR,
+                    Some('d') => ONE_DAY,
+                    _ => {
+                        bail!(
+                        "The polling_interval in \"{}\" does not have one of m, h or d as suffix",
+                        file_name()
+                    );
+                    }
+                };
+
+                let value: u32 = pi.parse().map_err(|e| {
+                    anyhow!(
+                        "Failed to parse polling_interval in \"{}\": {}",
+                        file_name(),
+                        e
+                    )
+                })?;
+
+                (value != 0).then_some(multiplier * value)
+            }
+            None => None,
+        };
+
+        let mut ch = Self {
+            name: channel_file.name,
+            display_name: channel_file.display_name,
+            description: channel_file.description,
+            url: channel_file.url.trim().to_string(),
+            polling_interval,
+            enabled: false,
+            bundle: None,
+        };
+
+        ch.update_enabled();
+
+        Ok(ch)
+    }
+
+    pub(super) fn from_directory(dir: &str) -> Result<Vec<Self>> {
+        // Find all .yaml files in CHANNELS_DIR
+        let mut dir_entries: Vec<DirEntry> = read_dir(dir)?
+            .filter_map(|dir_entry| dir_entry.ok())
+            .filter(|dir_entry| {
+                dir_entry
+                    .file_name()
+                    .as_os_str()
+                    .as_bytes()
+                    .ends_with(b".yaml")
+            })
+            .collect();
+
+        // And sort them alphabetically, so that 01_stable.yaml takes precedence over
+        // 05_testing.yaml.
+        dir_entries.sort_by_key(|dir_entry| dir_entry.file_name());
+
+        let mut channels: Vec<Self> = Vec::new();
+
+        for dir_entry in dir_entries {
+            let channel = Self::from_file(&dir_entry.path())?;
+
+            if channels.iter().any(|ch| ch.name == channel.name) {
+                bail!("Encountered duplicate channel name \"{}\"", channel.name);
+            }
+
+            channels.push(channel);
+        }
+
+        Ok(channels)
+    }
+
+    fn update_enabled(&mut self) {
+        // Which channels are enabled is decided based on which RAUC certificates are enabled.
+        let cert_file = self.name.clone() + ".cert.pem";
+        let cert_path = Path::new(ENABLE_DIR).join(cert_file);
+
+        self.enabled = cert_path.exists();
+    }
+
+    /// Ask RAUC to determine the version of the bundle on the server
+    pub(super) async fn poll(
+        &mut self,
+        proxy: &InstallerProxy<'_>,
+        slot_status: Option<&SlotStatus>,
+    ) -> Result<()> {
+        self.update_enabled();
+
+        self.bundle = None;
+
+        if self.enabled {
+            let (compatible, version) = proxy.info(&self.url).await?;
+            self.bundle = Some(UpstreamBundle::new(compatible, version, slot_status));
+        }
+
+        Ok(())
+    }
+}
+
+impl UpstreamBundle {
+    fn new(compatible: String, version: String, slot_status: Option<&SlotStatus>) -> Self {
+        let mut ub = Self {
+            compatible,
+            version,
+            newer_than_installed: false,
+        };
+
+        if let Some(slot_status) = slot_status {
+            ub.update_install(slot_status);
+        }
+
+        ub
+    }
+
+    pub(super) fn update_install(&mut self, slot_status: &SlotStatus) {
+        let slot_0_is_older = slot_status
+            .get("rootfs_0")
+            .and_then(|r| r.get("bundle_version"))
+            .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
+            .unwrap_or(true);
+
+        let slot_1_is_older = slot_status
+            .get("rootfs_1")
+            .and_then(|r| r.get("bundle_version"))
+            .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
+            .unwrap_or(true);
+
+        self.newer_than_installed = slot_0_is_older && slot_1_is_older;
+    }
+}

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -496,13 +496,8 @@ impl DutPwrThread {
             loop {
                 task::sleep(TASK_INTERVAL).await;
 
-                let curr_state = Some(state.load(Ordering::Relaxed).into());
-
-                // Only send publish events if the state changed
-                state_topic_task.modify(|prev_state| match prev_state != curr_state {
-                    true => curr_state,
-                    false => None,
-                });
+                let curr_state = state.load(Ordering::Relaxed).into();
+                state_topic_task.set_if_changed(curr_state);
             }
         });
 

--- a/src/iobus.rs
+++ b/src/iobus.rs
@@ -115,30 +115,14 @@ impl IoBus {
                     .recv_json::<ServerInfo>()
                     .await
                 {
-                    server_info_task.modify(|prev| {
-                        let need_update = prev.map(|p| p != si).unwrap_or(true);
-
-                        if need_update {
-                            Some(si)
-                        } else {
-                            None
-                        }
-                    });
+                    server_info_task.set_if_changed(si);
                 }
 
                 if let Ok(nodes) = http::get("http://127.0.0.1:8080/nodes/")
                     .recv_json::<Nodes>()
                     .await
                 {
-                    nodes_task.modify(|prev| {
-                        let need_update = prev.map(|n| n != nodes).unwrap_or(true);
-
-                        if need_update {
-                            Some(nodes)
-                        } else {
-                            None
-                        }
-                    });
+                    nodes_task.set_if_changed(nodes);
                 }
 
                 sleep(Duration::from_secs(1)).await;

--- a/src/setup_mode.rs
+++ b/src/setup_mode.rs
@@ -34,6 +34,7 @@ const AUTHORIZED_KEYS_PATH: &str = "/home/root/.ssh/authorized_keys";
 
 pub struct SetupMode {
     pub setup_mode: Arc<Topic<bool>>,
+    pub show_help: Arc<Topic<bool>>,
 }
 
 impl SetupMode {
@@ -128,6 +129,14 @@ impl SetupMode {
     pub fn new(bb: &mut BrokerBuilder, server: &mut Server<()>) -> Self {
         let this = Self {
             setup_mode: bb.topic("/v1/tac/setup_mode", true, false, true, Some(true), 1),
+            show_help: bb.topic(
+                "/v1/tac/display/show_help",
+                true,
+                false,
+                true,
+                Some(true),
+                1,
+            ),
         };
 
         this.handle_leave_requests(bb);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -60,8 +60,8 @@ pub struct Ui {
     res: UiResources,
 }
 
-/// Add a web endpoint that serves the current framebuffer as png
-fn serve_framebuffer(server: &mut Server<()>, screenshooter: ScreenShooter) {
+/// Add a web endpoint that serves the current display content as png
+fn serve_display(server: &mut Server<()>, screenshooter: ScreenShooter) {
     server.at("/v1/tac/display/content").get(move |_| {
         let png = screenshooter.as_png();
 
@@ -148,8 +148,8 @@ impl Ui {
 
         let display = Arc::new(Display::new());
 
-        // Expose the framebuffer as png via the web interface
-        serve_framebuffer(server, display.screenshooter());
+        // Expose the display content as png via the web interface
+        serve_display(server, display.screenshooter());
 
         Self {
             display,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ mod screens;
 mod widgets;
 
 use alerts::{AlertList, Alerter};
-use buttons::{handle_buttons, Button, ButtonEvent, PressDuration, Source};
+use buttons::{handle_buttons, Button, ButtonEvent, Direction, PressDuration, Source};
 pub use display::{Display, ScreenShooter};
 use screens::{splash, ActivatableScreen, AlertScreen, NormalScreen, Screen};
 
@@ -72,17 +72,20 @@ enum InputEvent {
 impl InputEvent {
     fn from_button(ev: ButtonEvent) -> Option<Self> {
         match ev {
-            ButtonEvent::Release {
+            ButtonEvent {
+                dir: Direction::Press,
                 btn: Button::Upper,
-                dur: _,
+                dur: PressDuration::Short,
                 src: _,
             } => Some(Self::NextScreen),
-            ButtonEvent::Release {
+            ButtonEvent {
+                dir: Direction::Release,
                 btn: Button::Lower,
                 dur: PressDuration::Short,
                 src,
             } => Some(Self::ToggleAction(src)),
-            ButtonEvent::Release {
+            ButtonEvent {
+                dir: Direction::Press,
                 btn: Button::Lower,
                 dur: PressDuration::Long,
                 src,

--- a/src/ui/alerts.rs
+++ b/src/ui/alerts.rs
@@ -1,0 +1,69 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use serde::{Deserialize, Serialize};
+
+use super::AlertScreen;
+use crate::broker::Topic;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AlertList(Vec<AlertScreen>);
+
+pub trait Alerter {
+    fn assert(&self, screen: AlertScreen);
+    fn deassert(&self, screen: AlertScreen);
+}
+
+impl AlertList {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn highest_priority(&self) -> Option<AlertScreen> {
+        self.0.last().copied()
+    }
+}
+
+impl Alerter for Topic<AlertList> {
+    fn assert(&self, screen: AlertScreen) {
+        self.modify(|list| {
+            let mut list = list.unwrap();
+
+            if list.0.iter().any(|s| s == &screen) {
+                None
+            } else {
+                list.0.push(screen);
+                list.0.sort();
+
+                Some(list)
+            }
+        });
+    }
+
+    fn deassert(&self, screen: AlertScreen) {
+        self.modify(|list| {
+            let mut list = list.unwrap();
+
+            if let Some(idx) = list.0.iter().position(|s| s == &screen) {
+                list.0.remove(idx);
+                Some(list)
+            } else {
+                None
+            }
+        });
+    }
+}

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -62,17 +62,17 @@ mod backend {
 
 use backend::Framebuffer;
 
-pub struct FramebufferDrawTarget {
+pub struct Display {
     fb: Framebuffer,
 }
 
-impl FramebufferDrawTarget {
-    pub fn new() -> FramebufferDrawTarget {
+impl Display {
+    pub fn new() -> Display {
         let mut fb = Framebuffer::new("/dev/fb0").unwrap();
         fb.var_screen_info.activate = 128; // FB_ACTIVATE_FORCE
         Framebuffer::put_var_screeninfo(&fb.device, &fb.var_screen_info).unwrap();
 
-        FramebufferDrawTarget { fb }
+        Display { fb }
     }
 
     pub fn clear(&mut self) {
@@ -105,7 +105,7 @@ impl FramebufferDrawTarget {
     }
 }
 
-impl DrawTarget for FramebufferDrawTarget {
+impl DrawTarget for Display {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
@@ -140,7 +140,7 @@ impl DrawTarget for FramebufferDrawTarget {
     }
 }
 
-impl OriginDimensions for FramebufferDrawTarget {
+impl OriginDimensions for Display {
     fn size(&self) -> Size {
         Size::new(self.fb.var_screen_info.xres, self.fb.var_screen_info.yres)
     }

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -99,12 +99,12 @@ impl Screen {
 
 #[async_trait]
 pub(super) trait ActiveScreen {
-    async fn deactivate(self: Box<Self>);
+    async fn deactivate(self: Box<Self>) -> Display;
 }
 
 pub(super) trait ActivatableScreen: Sync + Send {
     fn my_type(&self) -> Screen;
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen>;
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen>;
 }
 
 /// Draw static screen border containing a title and an indicator for the

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -128,17 +128,17 @@ fn draw_border(text: &str, screen: NormalScreen, display: &Display) {
         .draw(target)
         .unwrap();
 
-        Line::new(Point::new(0, 24), Point::new(230, 24))
+        Line::new(Point::new(0, 24), Point::new(240, 24))
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
             .draw(target)
             .unwrap();
 
         let screen_idx = screen as i32;
-        let num_screens = NormalScreen::Uart as i32 + 1;
+        let num_screens = (NormalScreen::Uart as i32) + 1;
         let x_start = screen_idx * 240 / num_screens;
         let x_end = (screen_idx + 1) * 240 / num_screens;
 
-        Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
+        Line::new(Point::new(x_start, 240), Point::new(x_end, 240))
             .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
             .draw(target)
             .unwrap();

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -15,7 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use async_std::sync::{Arc, Mutex};
+use async_std::sync::Arc;
 use async_trait::async_trait;
 use embedded_graphics::{
     mono_font::MonoTextStyle,
@@ -105,31 +105,31 @@ pub(super) trait MountableScreen: Sync + Send {
 
 /// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
-async fn draw_border(text: &str, screen: Screen, display: &Mutex<Display>) {
-    let mut display = display.lock().await;
-
-    Text::new(
-        text,
-        Point::new(8, 17),
-        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
-    )
-    .draw(&mut *display)
-    .unwrap();
-
-    Line::new(Point::new(0, 24), Point::new(230, 24))
-        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
-        .draw(&mut *display)
+async fn draw_border(text: &str, screen: Screen, display: &Display) {
+    display.with_lock(|target| {
+        Text::new(
+            text,
+            Point::new(8, 17),
+            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
+        )
+        .draw(target)
         .unwrap();
 
-    let screen_idx = screen as i32;
-    let num_screens = Screen::ScreenSaver as i32;
-    let x_start = screen_idx * 240 / num_screens;
-    let x_end = (screen_idx + 1) * 240 / num_screens;
+        Line::new(Point::new(0, 24), Point::new(230, 24))
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
+            .draw(target)
+            .unwrap();
 
-    Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
-        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
-        .draw(&mut *display)
-        .unwrap();
+        let screen_idx = screen as i32;
+        let num_screens = Screen::ScreenSaver as i32;
+        let x_start = screen_idx * 240 / num_screens;
+        let x_end = (screen_idx + 1) * 240 / num_screens;
+
+        Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
+            .draw(target)
+            .unwrap();
+    });
 }
 
 const fn row_anchor(row_num: u8) -> Point {

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -21,8 +21,8 @@ use embedded_graphics::{
     mono_font::MonoTextStyle,
     pixelcolor::BinaryColor,
     prelude::*,
-    primitives::{Line, PrimitiveStyle},
-    text::Text,
+    primitives::{Line, PrimitiveStyle, Rectangle},
+    text::{Alignment, Text},
 };
 use serde::{Deserialize, Serialize};
 
@@ -52,8 +52,9 @@ use usb::UsbScreen;
 
 use super::buttons;
 use super::widgets;
-use super::{Display, Ui, UiResources};
+use super::{Ui, UiResources};
 use crate::broker::Topic;
+use crate::ui::display::{Display, DisplayExclusive};
 use buttons::ButtonEvent;
 use widgets::UI_TEXT_FONT;
 
@@ -99,7 +100,7 @@ impl Screen {
 #[async_trait]
 pub(super) trait MountableScreen: Sync + Send {
     fn is_my_type(&self, screen: Screen) -> bool;
-    async fn mount(&mut self, ui: &Ui);
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>);
     async fn unmount(&mut self);
 }
 
@@ -136,6 +137,22 @@ const fn row_anchor(row_num: u8) -> Point {
     assert!(row_num < 8);
 
     Point::new(8, 52 + (row_num as i32) * 20)
+}
+
+pub(super) fn splash(target: &mut DisplayExclusive) -> Rectangle {
+    let ui_text_style: MonoTextStyle<BinaryColor> =
+        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+    let text = Text::with_alignment(
+        "Welcome",
+        Point::new(120, 120),
+        ui_text_style,
+        Alignment::Center,
+    );
+
+    text.draw(target).unwrap();
+
+    text.bounding_box()
 }
 
 pub(super) fn init(

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 mod dig_out;
 mod help;
 mod iobus;
+mod locator;
 mod power;
 mod reboot;
 mod screensaver;
@@ -41,6 +42,7 @@ mod usb;
 use dig_out::DigOutScreen;
 use help::HelpScreen;
 use iobus::IoBusScreen;
+use locator::LocatorScreen;
 use power::PowerScreen;
 use reboot::RebootConfirmScreen;
 use screensaver::ScreenSaverScreen;
@@ -71,6 +73,7 @@ pub enum NormalScreen {
 #[derive(Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Debug)]
 pub enum AlertScreen {
     ScreenSaver,
+    Locator,
     RebootConfirm,
     UpdateInstallation,
     Help,
@@ -169,6 +172,7 @@ pub(super) fn init(
     alerts: &Arc<Topic<AlertList>>,
     buttons: &Arc<Topic<ButtonEvent>>,
     reboot_message: &Arc<Topic<Option<String>>>,
+    locator: &Arc<Topic<bool>>,
 ) -> Vec<Box<dyn ActivatableScreen>> {
     vec![
         Box::new(DigOutScreen::new()),
@@ -182,5 +186,6 @@ pub(super) fn init(
         Box::new(RebootConfirmScreen::new(alerts, reboot_message)),
         Box::new(ScreenSaverScreen::new(buttons, alerts)),
         Box::new(SetupScreen::new(alerts, &res.setup_mode.setup_mode)),
+        Box::new(LocatorScreen::new(alerts, locator)),
     ]
 }

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -30,24 +30,24 @@ mod dig_out;
 mod help;
 mod iobus;
 mod power;
-mod rauc;
 mod reboot;
 mod screensaver;
 mod setup;
 mod system;
 mod uart;
+mod update_installation;
 mod usb;
 
 use dig_out::DigOutScreen;
 use help::HelpScreen;
 use iobus::IoBusScreen;
 use power::PowerScreen;
-use rauc::RaucScreen;
 use reboot::RebootConfirmScreen;
 use screensaver::ScreenSaverScreen;
 use setup::SetupScreen;
 use system::SystemScreen;
 use uart::UartScreen;
+use update_installation::UpdateInstallationScreen;
 use usb::UsbScreen;
 
 use super::buttons;
@@ -68,7 +68,7 @@ pub enum Screen {
     Uart,
     ScreenSaver,
     RebootConfirm,
-    Rauc,
+    UpdateInstallation,
     Setup,
     Help,
 }
@@ -85,7 +85,7 @@ impl Screen {
             Self::Uart => Self::ScreenSaver,
             Self::ScreenSaver => Self::DutPower,
             Self::RebootConfirm => Self::System,
-            Self::Rauc => Self::ScreenSaver,
+            Self::UpdateInstallation => Self::ScreenSaver,
             Self::Setup => Self::ScreenSaver,
             Self::Help => Self::ScreenSaver,
         }
@@ -93,7 +93,7 @@ impl Screen {
 
     /// Should screensaver be automatically enabled when in this screen?
     fn use_screensaver(&self) -> bool {
-        !matches!(self, Self::Rauc | Self::Setup | Self::Help)
+        !matches!(self, Self::UpdateInstallation | Self::Setup | Self::Help)
     }
 }
 
@@ -168,12 +168,12 @@ pub(super) fn init(
         Box::new(HelpScreen::new()),
         Box::new(IoBusScreen::new()),
         Box::new(PowerScreen::new()),
-        Box::new(RaucScreen::new(screen, &res.rauc.operation)),
         Box::new(RebootConfirmScreen::new()),
         Box::new(ScreenSaverScreen::new(buttons, screen)),
         Box::new(SetupScreen::new(screen, &res.setup_mode.setup_mode)),
         Box::new(SystemScreen::new()),
         Box::new(UartScreen::new()),
+        Box::new(UpdateInstallationScreen::new(screen, &res.rauc.operation)),
         Box::new(UsbScreen::new()),
     ]
 }

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -52,7 +52,7 @@ use usb::UsbScreen;
 
 use super::buttons;
 use super::widgets;
-use super::{FramebufferDrawTarget, Ui, UiResources};
+use super::{Display, Ui, UiResources};
 use crate::broker::Topic;
 use buttons::ButtonEvent;
 use widgets::UI_TEXT_FONT;
@@ -105,20 +105,20 @@ pub(super) trait MountableScreen: Sync + Send {
 
 /// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
-async fn draw_border(text: &str, screen: Screen, draw_target: &Arc<Mutex<FramebufferDrawTarget>>) {
-    let mut draw_target = draw_target.lock().await;
+async fn draw_border(text: &str, screen: Screen, display: &Arc<Mutex<Display>>) {
+    let mut display = display.lock().await;
 
     Text::new(
         text,
         Point::new(8, 17),
         MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
     )
-    .draw(&mut *draw_target)
+    .draw(&mut *display)
     .unwrap();
 
     Line::new(Point::new(0, 24), Point::new(230, 24))
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
-        .draw(&mut *draw_target)
+        .draw(&mut *display)
         .unwrap();
 
     let screen_idx = screen as i32;
@@ -128,7 +128,7 @@ async fn draw_border(text: &str, screen: Screen, draw_target: &Arc<Mutex<Framebu
 
     Line::new(Point::new(x_start, 238), Point::new(x_end, 238))
         .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
-        .draw(&mut *draw_target)
+        .draw(&mut *display)
         .unwrap();
 }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -36,6 +36,7 @@ mod screensaver;
 mod setup;
 mod system;
 mod uart;
+mod update_available;
 mod update_installation;
 mod usb;
 
@@ -49,6 +50,7 @@ use screensaver::ScreenSaverScreen;
 use setup::SetupScreen;
 use system::SystemScreen;
 use uart::UartScreen;
+use update_available::UpdateAvailableScreen;
 use update_installation::UpdateInstallationScreen;
 use usb::UsbScreen;
 
@@ -75,6 +77,7 @@ pub enum AlertScreen {
     ScreenSaver,
     Locator,
     RebootConfirm,
+    UpdateAvailable,
     UpdateInstallation,
     Help,
     Setup,
@@ -146,7 +149,7 @@ fn draw_border(text: &str, screen: NormalScreen, display: &Display) {
 }
 
 const fn row_anchor(row_num: u8) -> Point {
-    assert!(row_num < 8);
+    assert!(row_num < 9);
 
     Point::new(8, 52 + (row_num as i32) * 20)
 }
@@ -182,7 +185,13 @@ pub(super) fn init(
         Box::new(UartScreen::new()),
         Box::new(UsbScreen::new()),
         Box::new(HelpScreen::new(alerts, &res.setup_mode.show_help)),
-        Box::new(UpdateInstallationScreen::new(alerts, &res.rauc.operation)),
+        Box::new(UpdateInstallationScreen::new(
+            alerts,
+            &res.rauc.operation,
+            reboot_message,
+            &res.rauc.should_reboot,
+        )),
+        Box::new(UpdateAvailableScreen::new(alerts, &res.rauc.channels)),
         Box::new(RebootConfirmScreen::new(alerts, reboot_message)),
         Box::new(ScreenSaverScreen::new(buttons, alerts)),
         Box::new(SetupScreen::new(alerts, &res.setup_mode.setup_mode)),

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -52,7 +52,7 @@ use usb::UsbScreen;
 
 use super::buttons;
 use super::widgets;
-use super::{Ui, UiResources};
+use super::{InputEvent, Ui, UiResources};
 use crate::broker::Topic;
 use crate::ui::display::{Display, DisplayExclusive};
 use buttons::ButtonEvent;
@@ -100,6 +100,7 @@ impl Screen {
 #[async_trait]
 pub(super) trait ActiveScreen {
     async fn deactivate(self: Box<Self>) -> Display;
+    fn input(&mut self, ev: InputEvent);
 }
 
 pub(super) trait ActivatableScreen: Sync + Send {

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -105,7 +105,7 @@ pub(super) trait MountableScreen: Sync + Send {
 
 /// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
-async fn draw_border(text: &str, screen: Screen, display: &Arc<Mutex<Display>>) {
+async fn draw_border(text: &str, screen: Screen, display: &Mutex<Display>) {
     let mut display = display.lock().await;
 
     Text::new(

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -92,8 +92,6 @@ impl ActivatableScreen for DigOutScreen {
 
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         for (idx, _, status, voltage) in ports {
             let anchor_assert = row_anchor(idx * 4 + 1);
             let anchor_indicator = anchor_assert + OFFSET_INDICATOR;

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -156,9 +156,7 @@ impl MountableScreen for DigOutScreen {
                         dur: PressDuration::Long,
                         src: _,
                     } => {
-                        let port = &port_enables[highlighted as usize];
-
-                        port.modify(|prev| Some(!prev.unwrap_or(true)));
+                        port_enables[highlighted as usize].toggle(true);
                     }
                     ButtonEvent::Release {
                         btn: Button::Lower,

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -90,16 +90,14 @@ impl MountableScreen for DigOutScreen {
             let anchor_voltage = row_anchor(idx * 4 + 2);
             let anchor_bar = anchor_voltage + OFFSET_BAR;
 
-            {
-                let mut display = ui.display.lock().await;
-
+            ui.display.with_lock(|target| {
                 let ui_text_style: MonoTextStyle<BinaryColor> =
                     MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
                 Text::new(name, anchor_name, ui_text_style)
-                    .draw(&mut *display)
+                    .draw(target)
                     .unwrap();
-            }
+            });
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -60,11 +60,11 @@ impl MountableScreen for DigOutScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("Digital Out", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("Digital Out", SCREEN_TYPE, &ui.display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         let ports = [
@@ -91,19 +91,19 @@ impl MountableScreen for DigOutScreen {
             let anchor_bar = anchor_voltage + OFFSET_BAR;
 
             {
-                let mut draw_target = ui.draw_target.lock().await;
+                let mut display = ui.display.lock().await;
 
                 let ui_text_style: MonoTextStyle<BinaryColor> =
                     MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
                 Text::new(name, anchor_name, ui_text_style)
-                    .draw(&mut *draw_target)
+                    .draw(&mut *display)
                     .unwrap();
             }
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_assert,
                 Box::new(move |highlight: &u8| {
                     if *highlight == idx {
@@ -116,7 +116,7 @@ impl MountableScreen for DigOutScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_indicator,
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
@@ -126,14 +126,14 @@ impl MountableScreen for DigOutScreen {
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 voltage.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_voltage,
                 Box::new(|meas: &Measurement| format!("  Volt: {:>4.1}V", meas.value)),
             )));
 
             self.widgets.push(Box::new(DynamicWidget::bar(
                 voltage.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_bar,
                 WIDTH_BAR,
                 HEIGHT_BAR,

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -26,7 +26,7 @@ use embedded_graphics::{
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{draw_border, row_anchor, MountableScreen, Screen, Ui};
+use super::{draw_border, row_anchor, Display, MountableScreen, Screen, Ui};
 use crate::broker::{Native, SubscriptionHandle, Topic};
 use crate::measurement::Measurement;
 
@@ -59,12 +59,12 @@ impl MountableScreen for DigOutScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
-        draw_border("Digital Out", SCREEN_TYPE, &ui.display).await;
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
+        draw_border("Digital Out", SCREEN_TYPE, &display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.display.clone(),
+            display.clone(),
         )));
 
         let ports = [
@@ -90,7 +90,7 @@ impl MountableScreen for DigOutScreen {
             let anchor_voltage = row_anchor(idx * 4 + 2);
             let anchor_bar = anchor_voltage + OFFSET_BAR;
 
-            ui.display.with_lock(|target| {
+            display.with_lock(|target| {
                 let ui_text_style: MonoTextStyle<BinaryColor> =
                     MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
@@ -101,7 +101,7 @@ impl MountableScreen for DigOutScreen {
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_assert,
                 Box::new(move |highlight: &u8| {
                     if *highlight == idx {
@@ -114,7 +114,7 @@ impl MountableScreen for DigOutScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_indicator,
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
@@ -124,14 +124,14 @@ impl MountableScreen for DigOutScreen {
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 voltage.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_voltage,
                 Box::new(|meas: &Measurement| format!("  Volt: {:>4.1}V", meas.value)),
             )));
 
             self.widgets.push(Box::new(DynamicWidget::bar(
                 voltage.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_bar,
                 WIDTH_BAR,
                 HEIGHT_BAR,

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -15,19 +15,17 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use async_trait::async_trait;
-
 use embedded_graphics::{
     mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
 };
 
-use super::buttons::*;
 use super::widgets::*;
-use super::{draw_border, row_anchor, ActivatableScreen, ActiveScreen, Display, Screen, Ui};
-use crate::broker::{Native, SubscriptionHandle, Topic};
+use super::{
+    draw_border, row_anchor, ActivatableScreen, ActiveScreen, Display, InputEvent, Screen, Ui,
+};
+use crate::broker::Topic;
 use crate::measurement::Measurement;
 
 const SCREEN_TYPE: Screen = Screen::DigOut;
@@ -38,7 +36,7 @@ const WIDTH_BAR: u32 = 72;
 const HEIGHT_BAR: u32 = 18;
 
 pub struct DigOutScreen {
-    highlighted: Arc<Topic<u8>>,
+    highlighted: Arc<Topic<usize>>,
 }
 
 impl DigOutScreen {
@@ -51,7 +49,9 @@ impl DigOutScreen {
 
 struct Active {
     widgets: WidgetContainer,
-    button_handle: SubscriptionHandle<ButtonEvent, Native>,
+    port_enables: [Arc<Topic<bool>>; 2],
+    highlighted: Arc<Topic<usize>>,
+    screen: Arc<Topic<Screen>>,
 }
 
 impl ActivatableScreen for DigOutScreen {
@@ -106,8 +106,8 @@ impl ActivatableScreen for DigOutScreen {
                     self.highlighted.clone(),
                     display,
                     anchor_assert,
-                    Box::new(move |highlight: &u8| {
-                        if *highlight == idx {
+                    Box::new(move |highlight| {
+                        if *highlight == (idx as usize) {
                             "> Asserted:".into()
                         } else {
                             "  Asserted:".into()
@@ -149,45 +149,15 @@ impl ActivatableScreen for DigOutScreen {
             });
         }
 
-        let (mut button_events, button_handle) = ui.buttons.clone().subscribe_unbounded();
         let port_enables = [ui.res.dig_io.out_0.clone(), ui.res.dig_io.out_1.clone()];
-        let port_highlight = self.highlighted.clone();
+        let highlighted = self.highlighted.clone();
         let screen = ui.screen.clone();
-
-        spawn(async move {
-            while let Some(ev) = button_events.next().await {
-                let highlighted = port_highlight.get().await;
-
-                match ev {
-                    ButtonEvent::Release {
-                        btn: Button::Lower,
-                        dur: PressDuration::Long,
-                        src: _,
-                    } => {
-                        port_enables[highlighted as usize].toggle(true);
-                    }
-                    ButtonEvent::Release {
-                        btn: Button::Lower,
-                        dur: PressDuration::Short,
-                        src: _,
-                    } => {
-                        port_highlight.set((highlighted + 1) % 2);
-                    }
-                    ButtonEvent::Release {
-                        btn: Button::Upper,
-                        dur: _,
-                        src: _,
-                    } => {
-                        screen.set(SCREEN_TYPE.next());
-                    }
-                    _ => {}
-                }
-            }
-        });
 
         let active = Active {
             widgets,
-            button_handle,
+            port_enables,
+            highlighted,
+            screen,
         };
 
         Box::new(active)
@@ -197,7 +167,20 @@ impl ActivatableScreen for DigOutScreen {
 #[async_trait]
 impl ActiveScreen for Active {
     async fn deactivate(mut self: Box<Self>) -> Display {
-        self.button_handle.unsubscribe();
         self.widgets.destroy().await
+    }
+
+    fn input(&mut self, ev: InputEvent) {
+        let highlighted = self.highlighted.try_get().unwrap_or(0);
+
+        match ev {
+            InputEvent::NextScreen => self.screen.set(SCREEN_TYPE.next()),
+            InputEvent::ToggleAction(_) => {
+                self.highlighted.set((highlighted + 1) % 2);
+            }
+            InputEvent::PerformAction(_) => {
+                self.port_enables[highlighted].toggle(true);
+            }
+        }
     }
 }

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -113,7 +113,7 @@ impl MountableScreen for HelpScreen {
                         btn: Button::Lower,
                         dur: PressDuration::Short,
                         src: _,
-                    } => up.modify(|a| Some(!a.unwrap_or(false))),
+                    } => up.toggle(false),
                     ButtonEvent::Release {
                         btn: Button::Lower,
                         dur: PressDuration::Long,

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -78,14 +78,14 @@ impl MountableScreen for HelpScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             page.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Point::new(8, 24),
             Box::new(|page| PAGES[*page].into()),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             up.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Point::new(8, 200),
             Box::new(|up| match up {
                 false => "  Scroll up".into(),
@@ -95,7 +95,7 @@ impl MountableScreen for HelpScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             up.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Point::new(8, 220),
             Box::new(|up| match up {
                 false => "> Scroll down".into(),

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use std::sync::Arc;
+
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -22,7 +24,7 @@ use embedded_graphics::prelude::Point;
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{MountableScreen, Screen, Ui};
+use super::{Display, MountableScreen, Screen, Ui};
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
 const SCREEN_TYPE: Screen = Screen::Help;
@@ -72,20 +74,20 @@ impl MountableScreen for HelpScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
         let up = Topic::anonymous(Some(false));
         let page = Topic::anonymous(Some(0));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             page.clone(),
-            ui.display.clone(),
+            display.clone(),
             Point::new(8, 24),
             Box::new(|page| PAGES[*page].into()),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             up.clone(),
-            ui.display.clone(),
+            display.clone(),
             Point::new(8, 200),
             Box::new(|up| match up {
                 false => "  Scroll up".into(),
@@ -95,7 +97,7 @@ impl MountableScreen for HelpScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             up.clone(),
-            ui.display.clone(),
+            display,
             Point::new(8, 220),
             Box::new(|up| match up {
                 false => "> Scroll down".into(),

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -15,8 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::sync::Arc;
-
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -72,7 +70,7 @@ impl ActivatableScreen for HelpScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         let mut widgets = WidgetContainer::new(display);
 
         let up = Topic::anonymous(Some(false));
@@ -159,8 +157,8 @@ impl ActivatableScreen for HelpScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -142,7 +142,7 @@ impl MountableScreen for IoBusScreen {
                         btn: Button::Lower,
                         dur: PressDuration::Long,
                         src: _,
-                    } => iobus_pwr_en.modify(|prev| Some(!prev.unwrap_or(true))),
+                    } => iobus_pwr_en.toggle(true),
                     ButtonEvent::Release {
                         btn: Button::Upper,
                         dur: _,

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -15,8 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::sync::Arc;
-
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -53,7 +51,7 @@ impl ActivatableScreen for IoBusScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         draw_border("IOBus", SCREEN_TYPE, &display);
 
         let ui_text_style: MonoTextStyle<BinaryColor> =
@@ -176,8 +174,8 @@ impl ActivatableScreen for IoBusScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -56,28 +56,26 @@ impl MountableScreen for IoBusScreen {
     async fn mount(&mut self, ui: &Ui) {
         draw_border("IOBus", SCREEN_TYPE, &ui.display).await;
 
-        {
-            let mut display = ui.display.lock().await;
-
+        ui.display.with_lock(|target| {
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
             Text::new("CAN Status:", row_anchor(0), ui_text_style)
-                .draw(&mut *display)
+                .draw(target)
                 .unwrap();
 
             Text::new("LSS Scan Status:", row_anchor(1), ui_text_style)
-                .draw(&mut *display)
+                .draw(target)
                 .unwrap();
 
             Text::new("Power Fault:", row_anchor(2), ui_text_style)
-                .draw(&mut *display)
+                .draw(target)
                 .unwrap();
 
             Text::new("> Power On:", row_anchor(5), ui_text_style)
-                .draw(&mut *display)
+                .draw(target)
                 .unwrap();
-        }
+        });
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.iobus.nodes.clone(),

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -85,8 +85,6 @@ impl ActivatableScreen for IoBusScreen {
             )
         });
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         widgets.push(|display| {
             DynamicWidget::indicator(
                 ui.res.iobus.server_info.clone(),

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -54,46 +54,46 @@ impl MountableScreen for IoBusScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("IOBus", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("IOBus", SCREEN_TYPE, &ui.display).await;
 
         {
-            let mut draw_target = ui.draw_target.lock().await;
+            let mut display = ui.display.lock().await;
 
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
             Text::new("CAN Status:", row_anchor(0), ui_text_style)
-                .draw(&mut *draw_target)
+                .draw(&mut *display)
                 .unwrap();
 
             Text::new("LSS Scan Status:", row_anchor(1), ui_text_style)
-                .draw(&mut *draw_target)
+                .draw(&mut *display)
                 .unwrap();
 
             Text::new("Power Fault:", row_anchor(2), ui_text_style)
-                .draw(&mut *draw_target)
+                .draw(&mut *display)
                 .unwrap();
 
             Text::new("> Power On:", row_anchor(5), ui_text_style)
-                .draw(&mut *draw_target)
+                .draw(&mut *display)
                 .unwrap();
         }
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.iobus.nodes.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(3),
             Box::new(move |nodes: &Nodes| format!("Connected Nodes:  {}", nodes.result.len())),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::indicator(
             ui.res.iobus.server_info.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(0) + OFFSET_INDICATOR,
             Box::new(|info: &ServerInfo| match info.can_tx_error {
                 false => IndicatorState::On,
@@ -103,7 +103,7 @@ impl MountableScreen for IoBusScreen {
 
         self.widgets.push(Box::new(DynamicWidget::indicator(
             ui.res.iobus.server_info.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(1) + OFFSET_INDICATOR,
             Box::new(|info: &ServerInfo| match info.lss_state {
                 LSSState::Scanning => IndicatorState::On,
@@ -113,7 +113,7 @@ impl MountableScreen for IoBusScreen {
 
         self.widgets.push(Box::new(DynamicWidget::indicator(
             ui.res.dig_io.iobus_flt_fb.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(2) + OFFSET_INDICATOR,
             Box::new(|state: &bool| match *state {
                 true => IndicatorState::Error,
@@ -123,7 +123,7 @@ impl MountableScreen for IoBusScreen {
 
         self.widgets.push(Box::new(DynamicWidget::indicator(
             ui.res.regulators.iobus_pwr_en.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(5) + OFFSET_INDICATOR,
             Box::new(|state: &bool| match *state {
                 true => IndicatorState::On,

--- a/src/ui/screens/locator.rs
+++ b/src/ui/screens/locator.rs
@@ -1,0 +1,158 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::time::Instant;
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+use async_trait::async_trait;
+use embedded_graphics::{
+    mono_font::MonoTextStyle,
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{Line, PrimitiveStyle},
+    text::{Alignment, Text},
+};
+
+use super::widgets::*;
+use super::{
+    ActivatableScreen, ActiveScreen, AlertList, AlertScreen, Alerter, Display, InputEvent, Screen,
+    Ui,
+};
+use crate::broker::Topic;
+
+const SCREEN_TYPE: AlertScreen = AlertScreen::Locator;
+
+pub struct LocatorScreen;
+
+struct Active {
+    locator: Arc<Topic<bool>>,
+    widgets: WidgetContainer,
+}
+
+impl LocatorScreen {
+    pub fn new(alerts: &Arc<Topic<AlertList>>, locator: &Arc<Topic<bool>>) -> Self {
+        let (mut locator_events, _) = locator.clone().subscribe_unbounded();
+        let alerts = alerts.clone();
+
+        spawn(async move {
+            while let Some(locator) = locator_events.next().await {
+                if locator {
+                    alerts.assert(SCREEN_TYPE);
+                } else {
+                    alerts.deassert(SCREEN_TYPE);
+                }
+            }
+        });
+
+        Self
+    }
+}
+
+impl ActivatableScreen for LocatorScreen {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        let ui_text_style: MonoTextStyle<BinaryColor> =
+            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+        display.with_lock(|target| {
+            Text::with_alignment(
+                "Locating this TAC",
+                Point::new(120, 80),
+                ui_text_style,
+                Alignment::Center,
+            )
+            .draw(target)
+            .unwrap();
+
+            Text::with_alignment(
+                "> Found it!",
+                Point::new(120, 200),
+                ui_text_style,
+                Alignment::Center,
+            )
+            .draw(target)
+            .unwrap();
+        });
+
+        let mut widgets = WidgetContainer::new(display);
+
+        widgets.push(|display| {
+            DynamicWidget::text_center(
+                ui.res.network.hostname.clone(),
+                display,
+                Point::new(120, 130),
+                Box::new(|hostname| hostname.clone()),
+            )
+        });
+
+        let start = Instant::now();
+
+        widgets.push(|display| {
+            DynamicWidget::new(
+                ui.res.adc.time.clone(),
+                display,
+                Box::new(move |now, target| {
+                    // Blink a bar below the hostname at 2Hz
+                    let on = (now.duration_since(start).as_millis() / 500) % 2 == 0;
+
+                    if on {
+                        let line = Line::new(Point::new(40, 135), Point::new(200, 135))
+                            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2));
+
+                        line.draw(target).unwrap();
+
+                        Some(line.bounding_box())
+                    } else {
+                        None
+                    }
+                }),
+            )
+        });
+
+        let locator = ui.locator.clone();
+
+        let active = Active { locator, widgets };
+
+        Box::new(active)
+    }
+}
+
+#[async_trait]
+impl ActiveScreen for Active {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.widgets.destroy().await
+    }
+
+    fn input(&mut self, ev: InputEvent) {
+        match ev {
+            InputEvent::NextScreen => {}
+            InputEvent::ToggleAction(_) => {}
+            InputEvent::PerformAction(_) => {
+                self.locator.set(false);
+            }
+        }
+    }
+}

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -15,8 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::sync::Arc;
-
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -56,7 +54,7 @@ impl ActivatableScreen for PowerScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         draw_border("DUT Power", SCREEN_TYPE, &display);
 
         let mut widgets = WidgetContainer::new(display);
@@ -181,8 +179,8 @@ impl ActivatableScreen for PowerScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -60,8 +60,6 @@ impl ActivatableScreen for PowerScreen {
 
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         widgets.push(|display| {
             DynamicWidget::text(
                 ui.res.adc.pwr_volt.topic.clone(),

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -57,23 +57,23 @@ impl MountableScreen for PowerScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("DUT Power", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("DUT Power", SCREEN_TYPE, &ui.display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.adc.pwr_volt.topic.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(0),
             Box::new(|meas: &Measurement| format!("V: {:-6.3}V", meas.value)),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.adc.pwr_volt.topic.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(0) + OFFSET_BAR,
             WIDTH_BAR,
             HEIGHT_BAR,
@@ -82,14 +82,14 @@ impl MountableScreen for PowerScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.adc.pwr_curr.topic.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(1),
             Box::new(|meas: &Measurement| format!("I: {:-6.3}A", meas.value)),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.adc.pwr_curr.topic.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(1) + OFFSET_BAR,
             WIDTH_BAR,
             HEIGHT_BAR,
@@ -98,7 +98,7 @@ impl MountableScreen for PowerScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.dut_pwr.state.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(3),
             Box::new(|state: &OutputState| match state {
                 OutputState::On => "> On".into(),
@@ -114,7 +114,7 @@ impl MountableScreen for PowerScreen {
 
         self.widgets.push(Box::new(DynamicWidget::indicator(
             ui.res.dut_pwr.state.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(3) + OFFSET_INDICATOR,
             Box::new(|state: &OutputState| match state {
                 OutputState::On => IndicatorState::On,

--- a/src/ui/screens/rauc.rs
+++ b/src/ui/screens/rauc.rs
@@ -26,7 +26,7 @@ use crate::broker::Topic;
 use crate::dbus::rauc::Progress;
 
 use super::widgets::*;
-use super::{MountableScreen, Screen, Ui};
+use super::{Display, MountableScreen, Screen, Ui};
 
 const SCREEN_TYPE: Screen = Screen::Rauc;
 
@@ -67,15 +67,15 @@ impl MountableScreen for RaucScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.display.clone(),
+            display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text_center(
             ui.res.rauc.progress.clone(),
-            ui.display.clone(),
+            display.clone(),
             Point::new(120, 100),
             Box::new(|progress: &Progress| {
                 let (_, text) = progress.message.split_whitespace().fold(
@@ -104,7 +104,7 @@ impl MountableScreen for RaucScreen {
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.rauc.progress.clone(),
-            ui.display.clone(),
+            display,
             Point::new(20, 180),
             200,
             18,

--- a/src/ui/screens/rauc.rs
+++ b/src/ui/screens/rauc.rs
@@ -70,12 +70,12 @@ impl MountableScreen for RaucScreen {
     async fn mount(&mut self, ui: &Ui) {
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text_center(
             ui.res.rauc.progress.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Point::new(120, 100),
             Box::new(|progress: &Progress| {
                 let (_, text) = progress.message.split_whitespace().fold(
@@ -104,7 +104,7 @@ impl MountableScreen for RaucScreen {
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.rauc.progress.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Point::new(20, 180),
             200,
             18,

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -45,32 +45,36 @@ impl RebootConfirmScreen {
     }
 }
 
-fn rly(display: &mut Display) {
+fn rly(display: &Display) {
     let text_style: MonoTextStyle<BinaryColor> = MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-    Text::with_alignment(
-        "Really reboot?\nLong press lower\nbutton to confirm.",
-        Point::new(120, 120),
-        text_style,
-        Alignment::Center,
-    )
-    .draw(display)
-    .unwrap();
+    display.with_lock(|target| {
+        Text::with_alignment(
+            "Really reboot?\nLong press lower\nbutton to confirm.",
+            Point::new(120, 120),
+            text_style,
+            Alignment::Center,
+        )
+        .draw(target)
+        .unwrap();
+    });
 }
 
-fn brb(display: &mut Display) {
+fn brb(display: &Display) {
     let text_style: MonoTextStyle<BinaryColor> = MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
     display.clear();
 
-    Text::with_alignment(
-        "Hold tight\nBe right back",
-        Point::new(120, 120),
-        text_style,
-        Alignment::Center,
-    )
-    .draw(display)
-    .unwrap();
+    display.with_lock(|target| {
+        Text::with_alignment(
+            "Hold tight\nBe right back",
+            Point::new(120, 120),
+            text_style,
+            Alignment::Center,
+        )
+        .draw(target)
+        .unwrap();
+    });
 }
 
 #[async_trait]
@@ -81,7 +85,7 @@ impl MountableScreen for RebootConfirmScreen {
 
     async fn mount(&mut self, ui: &Ui) {
         let display = ui.display.clone();
-        rly(&mut *display.lock().await);
+        rly(&display);
 
         let (mut button_events, buttons_handle) = ui.buttons.clone().subscribe_unbounded();
         let screen = ui.screen.clone();
@@ -95,7 +99,7 @@ impl MountableScreen for RebootConfirmScreen {
                         dur: PressDuration::Long,
                         src: _,
                     } => {
-                        brb(&mut *display.lock().await);
+                        brb(&display);
                         reboot.set(true);
                         break;
                     }

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use std::sync::Arc;
+
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -83,8 +85,7 @@ impl MountableScreen for RebootConfirmScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
-        let display = ui.display.clone();
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
         rly(&display);
 
         let (mut button_events, buttons_handle) = ui.buttons.clone().subscribe_unbounded();

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -29,7 +29,7 @@ use embedded_graphics::{
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{FramebufferDrawTarget, MountableScreen, Screen, Ui};
+use super::{Display, MountableScreen, Screen, Ui};
 
 const SCREEN_TYPE: Screen = Screen::RebootConfirm;
 
@@ -45,7 +45,7 @@ impl RebootConfirmScreen {
     }
 }
 
-fn rly(draw_target: &mut FramebufferDrawTarget) {
+fn rly(display: &mut Display) {
     let text_style: MonoTextStyle<BinaryColor> = MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
     Text::with_alignment(
@@ -54,14 +54,14 @@ fn rly(draw_target: &mut FramebufferDrawTarget) {
         text_style,
         Alignment::Center,
     )
-    .draw(draw_target)
+    .draw(display)
     .unwrap();
 }
 
-fn brb(draw_target: &mut FramebufferDrawTarget) {
+fn brb(display: &mut Display) {
     let text_style: MonoTextStyle<BinaryColor> = MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-    draw_target.clear();
+    display.clear();
 
     Text::with_alignment(
         "Hold tight\nBe right back",
@@ -69,7 +69,7 @@ fn brb(draw_target: &mut FramebufferDrawTarget) {
         text_style,
         Alignment::Center,
     )
-    .draw(draw_target)
+    .draw(display)
     .unwrap();
 }
 
@@ -80,8 +80,8 @@ impl MountableScreen for RebootConfirmScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        let draw_target = ui.draw_target.clone();
-        rly(&mut *draw_target.lock().await);
+        let display = ui.display.clone();
+        rly(&mut *display.lock().await);
 
         let (mut button_events, buttons_handle) = ui.buttons.clone().subscribe_unbounded();
         let screen = ui.screen.clone();
@@ -95,7 +95,7 @@ impl MountableScreen for RebootConfirmScreen {
                         dur: PressDuration::Long,
                         src: _,
                     } => {
-                        brb(&mut *draw_target.lock().await);
+                        brb(&mut *display.lock().await);
                         reboot.set(true);
                         break;
                     }

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -143,12 +143,12 @@ impl MountableScreen for ScreenSaverScreen {
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::new(
             ui.res.adc.time.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             Box::new(move |_, target| {
                 let ui_text_style: MonoTextStyle<BinaryColor> =
                     MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -173,7 +173,7 @@ impl MountableScreen for ScreenSaverScreen {
                         btn: Button::Lower,
                         dur: _,
                         src: _,
-                    } => locator.modify(|prev| Some(!prev.unwrap_or(false))),
+                    } => locator.toggle(false),
                     ButtonEvent::Release {
                         btn: Button::Upper,
                         dur: _,

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -35,7 +35,7 @@ use embedded_graphics::{
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{MountableScreen, Screen, Ui};
+use super::{Display, MountableScreen, Screen, Ui};
 
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
@@ -134,7 +134,7 @@ impl MountableScreen for ScreenSaverScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
         let hostname = ui.res.network.hostname.get().await;
         let bounce = BounceAnimation::new(Rectangle::with_corners(
             Point::new(0, 8),
@@ -143,12 +143,12 @@ impl MountableScreen for ScreenSaverScreen {
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.display.clone(),
+            display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::new(
             ui.res.adc.time.clone(),
-            ui.display.clone(),
+            display.clone(),
             Box::new(move |_, target| {
                 let ui_text_style: MonoTextStyle<BinaryColor> =
                     MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -132,7 +132,7 @@ impl ActivatableScreen for ScreenSaverScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         let hostname = ui.res.network.hostname.clone();
         let bounce = BounceAnimation::new(Rectangle::with_corners(
             Point::new(0, 8),
@@ -195,8 +195,8 @@ impl ActivatableScreen for ScreenSaverScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -134,8 +134,6 @@ impl ActivatableScreen for ScreenSaverScreen {
 
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         let hostname = ui.res.network.hostname.clone();
 
         widgets.push(|display| {

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -146,7 +146,7 @@ impl MountableScreen for SetupScreen {
         self.widgets.push(Box::new(
             DynamicWidget::text_aligned(
                 connectivity_topic,
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 Point::new(120, 55),
                 Box::new(|connectivity| match connectivity {
                     Connectivity::Nothing => {

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -77,7 +77,7 @@ impl ActivatableScreen for SetupScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         /* We want to display hints on how to connect to this TAC.
          * We want to show:
          * - An URL based on the hostname, e.g. http://lxatac-12345
@@ -173,9 +173,9 @@ impl ActivatableScreen for SetupScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.hostname_update_handle.unsubscribe();
         self.ip_update_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -19,12 +19,11 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::spawn;
 use async_trait::async_trait;
-
 use embedded_graphics::{prelude::Point, text::Alignment};
 use serde::{Deserialize, Serialize};
 
 use super::widgets::*;
-use super::{ActivatableScreen, ActiveScreen, Display, Screen, Ui};
+use super::{ActivatableScreen, ActiveScreen, Display, InputEvent, Screen, Ui};
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
 const SCREEN_TYPE: Screen = Screen::Setup;
@@ -178,4 +177,6 @@ impl ActiveScreen for Active {
         self.ip_update_handle.unsubscribe();
         self.widgets.destroy().await
     }
+
+    fn input(&mut self, _ev: InputEvent) {}
 }

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -67,7 +67,7 @@ impl SetupScreen {
 }
 
 struct Active {
-    widgets: Vec<Box<dyn AnyWidget>>,
+    widgets: WidgetContainer,
     hostname_update_handle: SubscriptionHandle<String, Native>,
     ip_update_handle: SubscriptionHandle<Vec<String>, Native>,
 }
@@ -140,9 +140,9 @@ impl ActivatableScreen for SetupScreen {
             }
         });
 
-        let mut widgets: Vec<Box<dyn AnyWidget>> = Vec::new();
+        let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(Box::new(
+        widgets.push(|display|
             DynamicWidget::text_aligned(
                 connectivity_topic,
                 display,
@@ -159,8 +159,6 @@ impl ActivatableScreen for SetupScreen {
                     ),
                 }),
                 Alignment::Center,
-            )
-            ,
         ));
 
         let active = Active {
@@ -178,9 +176,6 @@ impl ActiveScreen for Active {
     async fn deactivate(mut self: Box<Self>) {
         self.hostname_update_handle.unsubscribe();
         self.ip_update_handle.unsubscribe();
-
-        for mut widget in self.widgets.into_iter() {
-            widget.unmount().await
-        }
+        self.widgets.destroy().await;
     }
 }

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -24,7 +24,7 @@ use embedded_graphics::{prelude::Point, text::Alignment};
 use serde::{Deserialize, Serialize};
 
 use super::widgets::*;
-use super::{MountableScreen, Screen, Ui};
+use super::{Display, MountableScreen, Screen, Ui};
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
 const SCREEN_TYPE: Screen = Screen::Setup;
@@ -80,7 +80,7 @@ impl MountableScreen for SetupScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
         /* We want to display hints on how to connect to this TAC.
          * We want to show:
          * - An URL based on the hostname, e.g. http://lxatac-12345
@@ -146,7 +146,7 @@ impl MountableScreen for SetupScreen {
         self.widgets.push(Box::new(
             DynamicWidget::text_aligned(
                 connectivity_topic,
-                ui.display.clone(),
+                display,
                 Point::new(120, 55),
                 Box::new(|connectivity| match connectivity {
                     Connectivity::Nothing => {

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -173,7 +173,7 @@ impl MountableScreen for SystemScreen {
                     } => match action {
                         Action::Reboot => screen.set(Screen::RebootConfirm),
                         Action::Help => screen.set(Screen::Help),
-                        Action::SetupMode => setup_mode.modify(|prev| Some(!prev.unwrap_or(true))),
+                        Action::SetupMode => setup_mode.set(true),
                     },
                     ButtonEvent::Release {
                         btn: Button::Lower,

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -67,25 +67,25 @@ impl MountableScreen for SystemScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("System Status", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("System Status", SCREEN_TYPE, &ui.display).await;
 
         let highlighted = Topic::anonymous(Some(Action::Reboot));
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.temperatures.soc_temperature.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(0),
             Box::new(|meas: &Measurement| format!("SoC:    {:.0}C", meas.value)),
         )));
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.network.uplink_interface.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(1),
             Box::new(|info: &LinkInfo| match info.carrier {
                 true => format!("Uplink: {}MBit/s", info.speed),
@@ -95,7 +95,7 @@ impl MountableScreen for SystemScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.network.dut_interface.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(2),
             Box::new(|info: &LinkInfo| match info.carrier {
                 true => format!("DUT:    {}MBit/s", info.speed),
@@ -105,7 +105,7 @@ impl MountableScreen for SystemScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             ui.res.network.bridge_interface.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(3),
             Box::new(|ips: &Vec<String>| {
                 let ip = ips.get(0).map(|s| s.as_str()).unwrap_or("-");
@@ -115,7 +115,7 @@ impl MountableScreen for SystemScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             highlighted.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(5),
             Box::new(|action| match action {
                 Action::Reboot => "> Reboot".into(),
@@ -125,7 +125,7 @@ impl MountableScreen for SystemScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             highlighted.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(6),
             Box::new(|action| match action {
                 Action::Help => "> Help".into(),
@@ -135,7 +135,7 @@ impl MountableScreen for SystemScreen {
 
         self.widgets.push(Box::new(DynamicWidget::text(
             highlighted.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(7),
             Box::new(|action| match action {
                 Action::SetupMode => "> Setup Mode".into(),

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -75,8 +75,6 @@ impl ActivatableScreen for SystemScreen {
         let mut widgets = WidgetContainer::new(display);
         let highlighted = Topic::anonymous(Some(Action::Reboot));
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         widgets.push(|display| {
             DynamicWidget::text(
                 ui.res.temperatures.soc_temperature.clone(),

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -15,8 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::sync::Arc;
-
 use async_std::prelude::*;
 use async_std::task::spawn;
 use async_trait::async_trait;
@@ -66,7 +64,7 @@ impl ActivatableScreen for SystemScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         draw_border("System Status", SCREEN_TYPE, &display);
 
         let mut widgets = WidgetContainer::new(display);
@@ -215,8 +213,8 @@ impl ActivatableScreen for SystemScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -26,7 +26,7 @@ use crate::broker::{Native, SubscriptionHandle, Topic};
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{draw_border, MountableScreen, Screen, Ui};
+use super::{draw_border, Display, MountableScreen, Screen, Ui};
 
 const SCREEN_TYPE: Screen = Screen::Uart;
 
@@ -52,12 +52,12 @@ impl MountableScreen for UartScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
-        draw_border("DUT UART", SCREEN_TYPE, &ui.display).await;
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
+        draw_border("DUT UART", SCREEN_TYPE, &display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.display.clone(),
+            display.clone(),
         )));
 
         let ports = [
@@ -68,7 +68,7 @@ impl MountableScreen for UartScreen {
         for (idx, name, y, status) in ports {
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.display.clone(),
+                display.clone(),
                 Point::new(8, y),
                 Box::new(move |highlight: &u8| {
                     format!(
@@ -81,7 +81,7 @@ impl MountableScreen for UartScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.display.clone(),
+                display.clone(),
                 Point::new(160, y - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -53,11 +53,11 @@ impl MountableScreen for UartScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("DUT UART", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("DUT UART", SCREEN_TYPE, &ui.display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         let ports = [
@@ -68,7 +68,7 @@ impl MountableScreen for UartScreen {
         for (idx, name, y, status) in ports {
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 Point::new(8, y),
                 Box::new(move |highlight: &u8| {
                     format!(
@@ -81,7 +81,7 @@ impl MountableScreen for UartScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 Point::new(160, y - 10),
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -55,8 +55,6 @@ impl ActivatableScreen for UartScreen {
 
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         let ports = [
             (0, "UART RX EN", 52, &ui.res.dig_io.uart_rx_en),
             (1, "UART TX EN", 72, &ui.res.dig_io.uart_tx_en),

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -52,7 +52,7 @@ impl ActivatableScreen for UartScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         draw_border("DUT UART", SCREEN_TYPE, &display);
 
         let mut widgets = WidgetContainer::new(display);
@@ -140,8 +140,8 @@ impl ActivatableScreen for UartScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -108,7 +108,7 @@ impl MountableScreen for UartScreen {
                         btn: Button::Lower,
                         dur: PressDuration::Long,
                         src: _,
-                    } => port.modify(|prev| Some(!prev.unwrap_or(false))),
+                    } => port.toggle(false),
                     ButtonEvent::Release {
                         btn: Button::Lower,
                         dur: PressDuration::Short,

--- a/src/ui/screens/update_available.rs
+++ b/src/ui/screens/update_available.rs
@@ -1,0 +1,262 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+use async_trait::async_trait;
+use embedded_graphics::{
+    mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
+};
+use serde::{Deserialize, Serialize};
+
+use super::widgets::*;
+use super::{
+    row_anchor, ActivatableScreen, ActiveScreen, AlertList, AlertScreen, Alerter, Display,
+    InputEvent, Screen, Ui,
+};
+use crate::broker::Topic;
+use crate::dbus::rauc::Channel;
+
+const SCREEN_TYPE: AlertScreen = AlertScreen::UpdateAvailable;
+
+#[derive(Serialize, Deserialize, PartialEq, Clone)]
+enum Highlight {
+    Channel(usize),
+    Dismiss,
+}
+
+impl Highlight {
+    fn next(&self, num_channels: usize) -> Self {
+        if num_channels == 0 {
+            return Self::Dismiss;
+        }
+
+        match self {
+            Self::Channel(ch) if (ch + 1) >= num_channels => Self::Dismiss,
+            Self::Channel(ch) => Self::Channel(ch + 1),
+            Self::Dismiss => Self::Channel(0),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct Selection {
+    channels: Vec<Channel>,
+    highlight: Highlight,
+}
+
+impl Selection {
+    fn new() -> Self {
+        Self {
+            channels: Vec::new(),
+            highlight: Highlight::Dismiss,
+        }
+    }
+
+    fn have_update(&self) -> bool {
+        !self.channels.is_empty()
+    }
+
+    fn update_channels(&self, channels: Vec<Channel>) -> Option<Self> {
+        let channels: Vec<Channel> = channels
+            .into_iter()
+            .filter(|ch| {
+                ch.bundle
+                    .as_ref()
+                    .map(|b| b.newer_than_installed)
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        if channels == self.channels {
+            return None;
+        }
+
+        let highlight = match self.highlight {
+            Highlight::Channel(index) => {
+                let name = &self.channels[index].name;
+
+                match channels.iter().position(|ch| &ch.name == name) {
+                    Some(idx) => Highlight::Channel(idx),
+                    None => Highlight::Dismiss,
+                }
+            }
+            Highlight::Dismiss => Highlight::Dismiss,
+        };
+
+        Some(Self {
+            channels,
+            highlight,
+        })
+    }
+
+    fn toggle(self) -> Option<Self> {
+        let num_channels = self.channels.len();
+        let highlight = self.highlight.next(num_channels);
+
+        if highlight != self.highlight {
+            Some(Self {
+                channels: self.channels,
+                highlight,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn perform(&self, alerts: &Arc<Topic<AlertList>>, install: &Arc<Topic<String>>) {
+        match self.highlight {
+            Highlight::Channel(ch) => install.set(self.channels[ch].url.clone()),
+            Highlight::Dismiss => alerts.deassert(SCREEN_TYPE),
+        }
+    }
+}
+
+pub struct UpdateAvailableScreen {
+    selection: Arc<Topic<Selection>>,
+}
+
+struct Active {
+    widgets: WidgetContainer,
+    alerts: Arc<Topic<AlertList>>,
+    install: Arc<Topic<String>>,
+    selection: Arc<Topic<Selection>>,
+}
+
+impl UpdateAvailableScreen {
+    pub fn new(alerts: &Arc<Topic<AlertList>>, channels: &Arc<Topic<Vec<Channel>>>) -> Self {
+        let (mut channels_events, _) = channels.clone().subscribe_unbounded();
+        let alerts = alerts.clone();
+        let selection = Topic::anonymous(Some(Selection::new()));
+        let selection_task = selection.clone();
+
+        spawn(async move {
+            while let Some(channels) = channels_events.next().await {
+                selection_task.modify(|sel| sel.unwrap().update_channels(channels));
+
+                if selection_task.try_get().unwrap().have_update() {
+                    alerts.assert(SCREEN_TYPE);
+                } else {
+                    alerts.deassert(SCREEN_TYPE);
+                }
+            }
+        });
+
+        Self { selection }
+    }
+}
+
+impl ActivatableScreen for UpdateAvailableScreen {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        let mut widgets = WidgetContainer::new(display);
+
+        widgets.push(|display| {
+            DynamicWidget::new(
+                self.selection.clone(),
+                display,
+                Box::new(move |sel, target| {
+                    let ui_text_style: MonoTextStyle<BinaryColor> =
+                        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+                    let num_updates = sel.channels.len();
+
+                    let header = match num_updates {
+                        0 => "There are no updates\navailable.",
+                        1 => "There is an update\navailable.",
+                        _ => "There are updates\navailable.",
+                    };
+
+                    Text::new(header, row_anchor(0), ui_text_style)
+                        .draw(target)
+                        .unwrap();
+
+                    let sel_idx = match sel.highlight {
+                        Highlight::Channel(idx) => idx,
+                        Highlight::Dismiss => num_updates,
+                    };
+
+                    for (idx, ch) in sel.channels.iter().enumerate() {
+                        let text = format!(
+                            "{} Install {}",
+                            if idx == sel_idx { ">" } else { " " },
+                            ch.display_name,
+                        );
+
+                        Text::new(&text, row_anchor(idx as u8 + 3), ui_text_style)
+                            .draw(target)
+                            .unwrap();
+                    }
+
+                    let dismiss = match sel.highlight {
+                        Highlight::Channel(_) => "  Dismiss",
+                        Highlight::Dismiss => "> Dismiss",
+                    };
+
+                    Text::new(dismiss, row_anchor(num_updates as u8 + 3), ui_text_style)
+                        .draw(target)
+                        .unwrap();
+
+                    // Don't bother tracking the actual bounding box and instead
+                    // clear the whole screen on update.
+                    Some(target.bounding_box())
+                }),
+            )
+        });
+
+        let alerts = ui.alerts.clone();
+        let install = ui.res.rauc.install.clone();
+        let selection = self.selection.clone();
+
+        Box::new(Active {
+            widgets,
+            alerts,
+            install,
+            selection,
+        })
+    }
+}
+
+#[async_trait]
+impl ActiveScreen for Active {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.widgets.destroy().await
+    }
+
+    fn input(&mut self, ev: InputEvent) {
+        match ev {
+            InputEvent::NextScreen => {}
+            InputEvent::ToggleAction(_) => {
+                self.selection
+                    .modify(|selection| selection.and_then(|s| s.toggle()));
+            }
+            InputEvent::PerformAction(_) => {
+                if let Some(selection) = self.selection.try_get() {
+                    selection.perform(&self.alerts, &self.install);
+                }
+            }
+        }
+    }
+}

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -19,14 +19,12 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::spawn;
 use async_trait::async_trait;
-
 use embedded_graphics::prelude::*;
 
+use super::widgets::*;
+use super::{ActivatableScreen, ActiveScreen, Display, InputEvent, Screen, Ui};
 use crate::broker::Topic;
 use crate::dbus::rauc::Progress;
-
-use super::widgets::*;
-use super::{ActivatableScreen, ActiveScreen, Display, Screen, Ui};
 
 const SCREEN_TYPE: Screen = Screen::UpdateInstallation;
 
@@ -124,4 +122,6 @@ impl ActiveScreen for Active {
     async fn deactivate(mut self: Box<Self>) -> Display {
         self.widgets.destroy().await
     }
+
+    fn input(&mut self, _ev: InputEvent) {}
 }

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -66,7 +66,7 @@ impl ActivatableScreen for UpdateInstallationScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         let mut widgets = WidgetContainer::new(display);
 
         widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
@@ -121,7 +121,7 @@ impl ActivatableScreen for UpdateInstallationScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
-        self.widgets.destroy().await;
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -28,11 +28,11 @@ use crate::dbus::rauc::Progress;
 use super::widgets::*;
 use super::{ActivatableScreen, ActiveScreen, Display, Screen, Ui};
 
-const SCREEN_TYPE: Screen = Screen::Rauc;
+const SCREEN_TYPE: Screen = Screen::UpdateInstallation;
 
-pub struct RaucScreen;
+pub struct UpdateInstallationScreen;
 
-impl RaucScreen {
+impl UpdateInstallationScreen {
     pub fn new(screen: &Arc<Topic<Screen>>, operation: &Arc<Topic<String>>) -> Self {
         // Activate the rauc screen if an update is started and deactivate
         // if it is done
@@ -61,7 +61,7 @@ struct Active {
     widgets: Vec<Box<dyn AnyWidget>>,
 }
 
-impl ActivatableScreen for RaucScreen {
+impl ActivatableScreen for UpdateInstallationScreen {
     fn my_type(&self) -> Screen {
         SCREEN_TYPE
     }

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -63,8 +63,6 @@ impl ActivatableScreen for UpdateInstallationScreen {
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         widgets.push(|display| {
             DynamicWidget::text_center(
                 ui.res.rauc.progress.clone(),

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -163,7 +163,7 @@ impl MountableScreen for UsbScreen {
                         dur: PressDuration::Long,
                         src: _,
                     } => {
-                        port.modify(|prev| Some(!prev.unwrap_or(true)));
+                        port.toggle(true);
                     }
                     ButtonEvent::Release {
                         btn: Button::Lower,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -26,7 +26,7 @@ use embedded_graphics::{
 
 use super::buttons::*;
 use super::widgets::*;
-use super::{draw_border, row_anchor, MountableScreen, Screen, Ui};
+use super::{draw_border, row_anchor, Display, MountableScreen, Screen, Ui};
 use crate::broker::{Native, SubscriptionHandle, Topic};
 use crate::measurement::Measurement;
 
@@ -60,12 +60,12 @@ impl MountableScreen for UsbScreen {
         screen == SCREEN_TYPE
     }
 
-    async fn mount(&mut self, ui: &Ui) {
-        draw_border("USB Host", SCREEN_TYPE, &ui.display).await;
+    async fn mount(&mut self, ui: &Ui, display: Arc<Display>) {
+        draw_border("USB Host", SCREEN_TYPE, &display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.display.clone(),
+            display.clone(),
         )));
 
         let ports = [
@@ -89,7 +89,7 @@ impl MountableScreen for UsbScreen {
             ),
         ];
 
-        ui.display.with_lock(|target| {
+        display.with_lock(|target| {
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
@@ -100,7 +100,7 @@ impl MountableScreen for UsbScreen {
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.adc.usb_host_curr.topic.clone(),
-            ui.display.clone(),
+            display.clone(),
             row_anchor(0) + OFFSET_BAR,
             WIDTH_BAR,
             HEIGHT_BAR,
@@ -114,7 +114,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_text,
                 Box::new(move |highlight: &u8| {
                     format!("{} {}", if *highlight == idx { ">" } else { " " }, name,)
@@ -123,7 +123,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_indicator,
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
@@ -133,7 +133,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::bar(
                 current.clone(),
-                ui.display.clone(),
+                display.clone(),
                 anchor_bar,
                 WIDTH_BAR,
                 HEIGHT_BAR,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -74,8 +74,6 @@ impl ActivatableScreen for UsbScreen {
 
         let mut widgets = WidgetContainer::new(display);
 
-        widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
-
         let ports = [
             (
                 0,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -61,11 +61,11 @@ impl MountableScreen for UsbScreen {
     }
 
     async fn mount(&mut self, ui: &Ui) {
-        draw_border("USB Host", SCREEN_TYPE, &ui.draw_target).await;
+        draw_border("USB Host", SCREEN_TYPE, &ui.display).await;
 
         self.widgets.push(Box::new(DynamicWidget::locator(
             ui.locator_dance.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
         )));
 
         let ports = [
@@ -90,19 +90,19 @@ impl MountableScreen for UsbScreen {
         ];
 
         {
-            let mut draw_target = ui.draw_target.lock().await;
+            let mut display = ui.display.lock().await;
 
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
             Text::new("Total", row_anchor(0), ui_text_style)
-                .draw(&mut *draw_target)
+                .draw(&mut *display)
                 .unwrap();
         }
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.adc.usb_host_curr.topic.clone(),
-            ui.draw_target.clone(),
+            ui.display.clone(),
             row_anchor(0) + OFFSET_BAR,
             WIDTH_BAR,
             HEIGHT_BAR,
@@ -116,7 +116,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::text(
                 self.highlighted.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_text,
                 Box::new(move |highlight: &u8| {
                     format!("{} {}", if *highlight == idx { ">" } else { " " }, name,)
@@ -125,7 +125,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::indicator(
                 status.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_indicator,
                 Box::new(|state: &bool| match *state {
                     true => IndicatorState::On,
@@ -135,7 +135,7 @@ impl MountableScreen for UsbScreen {
 
             self.widgets.push(Box::new(DynamicWidget::bar(
                 current.clone(),
-                ui.draw_target.clone(),
+                ui.display.clone(),
                 anchor_bar,
                 WIDTH_BAR,
                 HEIGHT_BAR,

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -89,16 +89,14 @@ impl MountableScreen for UsbScreen {
             ),
         ];
 
-        {
-            let mut display = ui.display.lock().await;
-
+        ui.display.with_lock(|target| {
             let ui_text_style: MonoTextStyle<BinaryColor> =
                 MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
             Text::new("Total", row_anchor(0), ui_text_style)
-                .draw(&mut *display)
+                .draw(target)
                 .unwrap();
-        }
+        });
 
         self.widgets.push(Box::new(DynamicWidget::bar(
             ui.res.adc.usb_host_curr.topic.clone(),

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -60,10 +60,19 @@ impl ActivatableScreen for UsbScreen {
         SCREEN_TYPE
     }
 
-    fn activate(&mut self, ui: &Ui, display: Arc<Display>) -> Box<dyn ActiveScreen> {
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
         draw_border("USB Host", SCREEN_TYPE, &display);
 
-        let mut widgets = WidgetContainer::new(display.clone());
+        let ui_text_style: MonoTextStyle<BinaryColor> =
+            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+        display.with_lock(|target| {
+            Text::new("Total", row_anchor(0), ui_text_style)
+                .draw(target)
+                .unwrap();
+        });
+
+        let mut widgets = WidgetContainer::new(display);
 
         widgets.push(|display| DynamicWidget::locator(ui.locator_dance.clone(), display));
 
@@ -87,15 +96,6 @@ impl ActivatableScreen for UsbScreen {
                 &ui.res.adc.usb_host3_curr.topic,
             ),
         ];
-
-        display.with_lock(|target| {
-            let ui_text_style: MonoTextStyle<BinaryColor> =
-                MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
-
-            Text::new("Total", row_anchor(0), ui_text_style)
-                .draw(target)
-                .unwrap();
-        });
 
         widgets.push(|display| {
             DynamicWidget::bar(
@@ -198,8 +198,8 @@ impl ActivatableScreen for UsbScreen {
 
 #[async_trait]
 impl ActiveScreen for Active {
-    async fn deactivate(mut self: Box<Self>) {
+    async fn deactivate(mut self: Box<Self>) -> Display {
         self.buttons_handle.unsubscribe();
-        self.widgets.destroy().await;
+        self.widgets.destroy().await
     }
 }

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -29,7 +29,7 @@ use embedded_graphics::{
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use super::FramebufferDrawTarget;
+use super::Display;
 use crate::broker::{Native, SubscriptionHandle, Topic};
 
 pub const UI_TEXT_FONT: MonoFont = FONT_10X20;
@@ -41,8 +41,8 @@ pub enum IndicatorState {
     Unkown,
 }
 
-pub trait DrawFn<T>: Fn(&T, &mut FramebufferDrawTarget) -> Option<Rectangle> {}
-impl<T, U> DrawFn<T> for U where U: Fn(&T, &mut FramebufferDrawTarget) -> Option<Rectangle> {}
+pub trait DrawFn<T>: Fn(&T, &mut Display) -> Option<Rectangle> {}
+impl<T, U> DrawFn<T> for U where U: Fn(&T, &mut Display) -> Option<Rectangle> {}
 
 pub trait IndicatorFormatFn<T>: Fn(&T) -> IndicatorState {}
 impl<T, U> IndicatorFormatFn<T> for U where U: Fn(&T) -> IndicatorState {}
@@ -74,7 +74,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     ///   The widget system takes care of clearing this area before redrawing.
     pub fn new(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         draw_fn: Box<dyn DrawFn<T> + Sync + Send>,
     ) -> Self {
         let (mut rx, sub_handle) = topic.subscribe_unbounded();
@@ -107,7 +107,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     /// the fraction of the graph to fill.
     pub fn bar(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         anchor: Point,
         width: u32,
         height: u32,
@@ -141,7 +141,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     /// Draw an indicator bubble in an "On", "Off" or "Error" state
     pub fn indicator(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         anchor: Point,
         format_fn: Box<dyn IndicatorFormatFn<T> + Sync + Send>,
     ) -> Self {
@@ -207,7 +207,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     /// Draw self-updating text with configurable alignment
     pub fn text_aligned(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         anchor: Point,
         format_fn: Box<dyn TextFormatFn<T> + Sync + Send>,
         alignment: Alignment,
@@ -235,7 +235,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     /// Draw self-updating left aligned text
     pub fn text(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         anchor: Point,
         format_fn: Box<dyn TextFormatFn<T> + Sync + Send>,
     ) -> Self {
@@ -245,7 +245,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     /// Draw self-updating centered text
     pub fn text_center(
         topic: Arc<Topic<T>>,
-        target: Arc<Mutex<FramebufferDrawTarget>>,
+        target: Arc<Mutex<Display>>,
         anchor: Point,
         format_fn: Box<dyn TextFormatFn<T> + Sync + Send>,
     ) -> Self {
@@ -256,7 +256,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
 impl DynamicWidget<i32> {
     /// Draw an animated locator widget at the side of the screen
     /// (if the locator is active).
-    pub fn locator(topic: Arc<Topic<i32>>, target: Arc<Mutex<FramebufferDrawTarget>>) -> Self {
+    pub fn locator(topic: Arc<Topic<i32>>, target: Arc<Mutex<Display>>) -> Self {
         Self::new(
             topic,
             target,

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -297,36 +297,6 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
     }
 }
 
-impl DynamicWidget<i32> {
-    /// Draw an animated locator widget at the side of the screen
-    /// (if the locator is active).
-    pub fn locator(topic: Arc<Topic<i32>>, display: Arc<Display>) -> Self {
-        Self::new(
-            topic,
-            display,
-            Box::new(move |val, target| {
-                let size = 128 - (*val - 32).abs() * 4;
-
-                if size != 0 {
-                    let bounding = Rectangle::with_center(
-                        Point::new(240 - 5, 120),
-                        Size::new(10, size as u32),
-                    );
-
-                    bounding
-                        .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
-                        .draw(&mut *target)
-                        .unwrap();
-
-                    Some(bounding)
-                } else {
-                    None
-                }
-            }),
-        )
-    }
-}
-
 #[async_trait]
 pub trait AnyWidget: Send + Sync {
     async fn unmount(self: Box<Self>) -> Arc<Display>;

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -204,16 +204,7 @@ fn handle_port(bb: &mut BrokerBuilder, name: &'static str, base: &'static str) -
                     _ => panic!("Read unexpected value for USB port disable state"),
                 };
 
-                powered.modify(|prev| {
-                    let should_set = prev
-                        .map(|prev_powered| prev_powered != is_powered)
-                        .unwrap_or(true);
-
-                    match should_set {
-                        true => Some(is_powered),
-                        false => None,
-                    }
-                });
+                powered.set_if_changed(is_powered);
             }
 
             let id_product = read_to_string(&id_product_path).ok();
@@ -231,16 +222,7 @@ fn handle_port(bb: &mut BrokerBuilder, name: &'static str, base: &'static str) -
                 product: pro.trim().to_string(),
             });
 
-            device.modify(|prev| {
-                let should_set = prev
-                    .map(|prev_dev_info| prev_dev_info != dev_info)
-                    .unwrap_or(true);
-
-                match should_set {
-                    true => Some(dev_info),
-                    false => None,
-                }
-            });
+            device.set_if_changed(dev_info);
 
             sleep(POLL_INTERVAL).await;
         }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,7 +30,7 @@ import "@cloudscape-design/global-styles/index.css";
 import "./App.css";
 import { useMqttSubscription } from "./mqtt";
 import { ApiPickerButton, MqttButton } from "./MqttComponents";
-import { LocatorNotification } from "./TacComponents";
+import { ProgressNotification, LocatorNotification } from "./TacComponents";
 
 function Navigation() {
   const [activeHref, setActiveHref] = useState("#/");
@@ -128,6 +128,7 @@ function Notifications() {
   return (
     <>
       <ConnectionNotification />
+      <ProgressNotification />
       <LocatorNotification />
     </>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import { useMqttSubscription } from "./mqtt";
 import { ApiPickerButton, MqttButton } from "./MqttComponents";
 import {
   RebootNotification,
+  UpdateNotification,
   ProgressNotification,
   LocatorNotification,
 } from "./TacComponents";
@@ -134,6 +135,7 @@ function Notifications() {
       <ConnectionNotification />
       <RebootNotification />
       <ProgressNotification />
+      <UpdateNotification />
       <LocatorNotification />
     </>
   );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,9 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import React from "react";
+
+import Alert from "@cloudscape-design/components/alert";
+import Button from "@cloudscape-design/components/button";
 import AppLayout from "@cloudscape-design/components/app-layout";
 import SideNavigation from "@cloudscape-design/components/side-navigation";
 
@@ -95,6 +98,32 @@ function Navigation() {
   );
 }
 
+function ConnectionNotification() {
+  const hostname = useMqttSubscription("/v1/tac/network/hostname");
+
+  return (
+    <Alert
+      statusIconAriaLabel="Info"
+      visible={hostname === undefined}
+      action={
+        <Button onClick={(ev) => window.location.reload()}>Reload</Button>
+      }
+      header="Connection Lost"
+    >
+      There is currently no connection to the TAC. Wait for the connection to be
+      re-established or reload the page.
+    </Alert>
+  );
+}
+
+function Notifications() {
+  return (
+    <>
+      <ConnectionNotification />
+    </>
+  );
+}
+
 export default function App() {
   const [runningVersion, setRunningVersion] = useState<string | undefined>();
   const hostname = useMqttSubscription("/v1/tac/network/hostname");
@@ -131,6 +160,8 @@ export default function App() {
 
   return (
     <AppLayout
+      notifications={<Notifications />}
+      stickyNotifications={true}
       navigation={<Navigation />}
       content={<Outlet />}
       toolsHide={true}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,7 +29,8 @@ import "@cloudscape-design/global-styles/index.css";
 
 import "./App.css";
 import { useMqttSubscription } from "./mqtt";
-import { ApiPickerButton } from "./MqttComponents";
+import { ApiPickerButton, MqttButton } from "./MqttComponents";
+import { LocatorNotification } from "./TacComponents";
 
 function Navigation() {
   const [activeHref, setActiveHref] = useState("#/");
@@ -92,6 +93,13 @@ function Navigation() {
         ]}
       />
       <div className="nav_footer">
+        <MqttButton
+          iconName="search"
+          topic="/v1/tac/display/locator"
+          send={true}
+        >
+          Find this TAC
+        </MqttButton>
         <ApiPickerButton />
       </div>
     </>
@@ -120,6 +128,7 @@ function Notifications() {
   return (
     <>
       <ConnectionNotification />
+      <LocatorNotification />
     </>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,7 +30,11 @@ import "@cloudscape-design/global-styles/index.css";
 import "./App.css";
 import { useMqttSubscription } from "./mqtt";
 import { ApiPickerButton, MqttButton } from "./MqttComponents";
-import { ProgressNotification, LocatorNotification } from "./TacComponents";
+import {
+  RebootNotification,
+  ProgressNotification,
+  LocatorNotification,
+} from "./TacComponents";
 
 function Navigation() {
   const [activeHref, setActiveHref] = useState("#/");
@@ -128,6 +132,7 @@ function Notifications() {
   return (
     <>
       <ConnectionNotification />
+      <RebootNotification />
       <ProgressNotification />
       <LocatorNotification />
     </>

--- a/web/src/DashboardTac.tsx
+++ b/web/src/DashboardTac.tsx
@@ -166,38 +166,31 @@ export default function DashboardTac() {
           />
           <SpaceBetween size="m">
             <Box>
-              <Box variant="awsui-key-label">Upper Button</Box>
-              <SpaceBetween direction="horizontal" size="xs">
-                <MqttButton
-                  topic="/v1/tac/display/buttons"
-                  send={{ Release: { btn: "Upper", dur: "Short" } }}
-                >
-                  Short press
-                </MqttButton>
-                <MqttButton
-                  topic="/v1/tac/display/buttons"
-                  send={{ Release: { btn: "Upper", dur: "Long" } }}
-                >
-                  Long press
-                </MqttButton>
-              </SpaceBetween>
+              <Box variant="awsui-key-label">Next Screen</Box>
+              <MqttButton
+                topic="/v1/tac/display/buttons"
+                send={{ dir: "Press", btn: "Upper", dur: "Short" }}
+              >
+                Next Screen
+              </MqttButton>
             </Box>
             <Box>
-              <Box variant="awsui-key-label">Lower Button</Box>
-              <SpaceBetween direction="horizontal" size="xs">
-                <MqttButton
-                  topic="/v1/tac/display/buttons"
-                  send={{ Release: { btn: "Lower", dur: "Short" } }}
-                >
-                  Short press
-                </MqttButton>
-                <MqttButton
-                  topic="/v1/tac/display/buttons"
-                  send={{ Release: { btn: "Lower", dur: "Long" } }}
-                >
-                  Long press
-                </MqttButton>
-              </SpaceBetween>
+              <Box variant="awsui-key-label">Toggle Action</Box>
+              <MqttButton
+                topic="/v1/tac/display/buttons"
+                send={{ dir: "Release", btn: "Lower", dur: "Short" }}
+              >
+                Toggle Action
+              </MqttButton>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">Perform Action</Box>
+              <MqttButton
+                topic="/v1/tac/display/buttons"
+                send={{ dir: "Press", btn: "Lower", dur: "Long" }}
+              >
+                Perform Action
+              </MqttButton>
             </Box>
             <Box>
               <Box variant="awsui-key-label">Locator</Box>

--- a/web/src/DashboardTac.tsx
+++ b/web/src/DashboardTac.tsx
@@ -23,7 +23,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 
 import { MqttBox, MqttButton } from "./MqttComponents";
-import { RaucContainer } from "./TacComponents";
+import { UpdateContainer } from "./TacComponents";
 
 import { useEffect, useState } from "react";
 
@@ -195,7 +195,8 @@ export default function DashboardTac() {
           </SpaceBetween>
         </ColumnLayout>
       </Container>
-      <RaucContainer />
+
+      <UpdateContainer />
 
       <Container
         header={

--- a/web/src/DashboardTac.tsx
+++ b/web/src/DashboardTac.tsx
@@ -22,7 +22,7 @@ import Container from "@cloudscape-design/components/container";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import ColumnLayout from "@cloudscape-design/components/column-layout";
 
-import { MqttBox, MqttToggle, MqttButton } from "./MqttComponents";
+import { MqttBox, MqttButton } from "./MqttComponents";
 import { RaucContainer } from "./TacComponents";
 
 import { useEffect, useState } from "react";
@@ -191,10 +191,6 @@ export default function DashboardTac() {
               >
                 Perform Action
               </MqttButton>
-            </Box>
-            <Box>
-              <Box variant="awsui-key-label">Locator</Box>
-              <MqttToggle topic="/v1/tac/display/locator">Locator</MqttToggle>
             </Box>
           </SpaceBetween>
         </ColumnLayout>

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -27,7 +27,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Wizard from "@cloudscape-design/components/wizard";
 
-import { SlotStatus, RaucInstall } from "./TacComponents";
+import { SlotStatus } from "./TacComponents";
 import { LabgridService, LabgridConfig } from "./SettingsLabgrid";
 import { ConfigEditor } from "./ConfigEditor";
 import { useMqttState, useMqttAction } from "./mqtt";
@@ -302,11 +302,6 @@ function CustomBundleWizard(props: WizardProps) {
                 <Box>Sorry, this is not yet implemented</Box>
               </Container>
             ),
-          },
-          {
-            title: "Install Bundle",
-            description: "Install your vendored RAUC bundle",
-            content: <RaucInstall />,
           },
           {
             title: "Check Slot Status",

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -27,7 +27,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Wizard from "@cloudscape-design/components/wizard";
 
-import { RaucSlotStatus, RaucInstall } from "./TacComponents";
+import { SlotStatus, RaucInstall } from "./TacComponents";
 import { LabgridService, LabgridConfig } from "./SettingsLabgrid";
 import { ConfigEditor } from "./ConfigEditor";
 import { useMqttState, useMqttAction } from "./mqtt";
@@ -312,7 +312,7 @@ function CustomBundleWizard(props: WizardProps) {
             title: "Check Slot Status",
             description: "Make sure everything look correct",
             isOptional: true,
-            content: <RaucSlotStatus />,
+            content: <SlotStatus />,
           },
           {
             title: "Complete Setup",

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -179,7 +179,7 @@ export function SlotStatus() {
   }
 }
 
-export function UpdateStatus() {
+export function ProgressNotification() {
   const operation = useMqttSubscription<string>("/v1/tac/update/operation");
   const progress = useMqttSubscription<RaucProgress>("/v1/tac/update/progress");
   const last_error = useMqttSubscription<string>("/v1/tac/update/last_error");
@@ -199,12 +199,14 @@ export function UpdateStatus() {
     prev_operation.current = operation;
   }, [operation]);
 
+  let inner = null;
+
   if (installStep === RaucInstallStep.Installing) {
     let valid = progress !== undefined;
     let value = progress === undefined ? 0 : progress.percentage;
     let message = progress === undefined ? "" : progress.message;
 
-    return (
+    inner = (
       <ProgressBar
         status={valid ? "in-progress" : "error"}
         value={value}
@@ -215,17 +217,8 @@ export function UpdateStatus() {
   }
 
   if (installStep === RaucInstallStep.Done) {
-    if (last_error === undefined || last_error === "") {
-      return (
-        <ProgressBar
-          status={"success"}
-          value={100}
-          description="Done"
-          additionalInfo="Bundle installed successfully"
-        />
-      );
-    } else {
-      return (
+    if (last_error !== undefined && last_error !== "") {
+      inner = (
         <ProgressBar
           status={"error"}
           value={100}
@@ -237,12 +230,13 @@ export function UpdateStatus() {
   }
 
   return (
-    <ProgressBar
-      status={"in-progress"}
-      value={0}
-      description="Idle"
-      additionalInfo="No bundle is being installed"
-    />
+    <Alert
+      statusIconAriaLabel="Info"
+      header="Installing Operating System Update"
+      visible={inner !== null}
+    >
+      {inner}
+    </Alert>
   );
 }
 
@@ -259,7 +253,6 @@ export function UpdateContainer() {
       }
     >
       <SpaceBetween size="m">
-        <UpdateStatus />
         <SlotStatus />
       </SpaceBetween>
     </Container>

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -113,32 +113,6 @@ export function SlotStatus() {
           header={
             <Header
               variant="h3"
-              description="The bootloader is responsible for loading the Linux kernel"
-            >
-              Bootloader Slot
-            </Header>
-          }
-        >
-          <ColumnLayout columns={3} variant="text-grid">
-            <Box>
-              <Box variant="awsui-key-label">Status</Box>
-              <Box>{slot_status.bootloader_0.status}</Box>
-            </Box>
-            <Box>
-              <Box variant="awsui-key-label">Build Date</Box>
-              <Box>{slot_status.bootloader_0.bundle_build}</Box>
-            </Box>
-            <Box>
-              <Box variant="awsui-key-label">Installation Date</Box>
-              <Box>{slot_status.bootloader_0.installed_timestamp}</Box>
-            </Box>
-          </ColumnLayout>
-        </Container>
-
-        <Container
-          header={
-            <Header
-              variant="h3"
               description="The root file system contains your applications and settings"
             >
               Root Filesystem Slots
@@ -178,6 +152,32 @@ export function SlotStatus() {
             selectionType="single"
             trackBy="name"
           />
+        </Container>
+
+        <Container
+          header={
+            <Header
+              variant="h3"
+              description="The bootloader is responsible for loading the Linux kernel"
+            >
+              Bootloader Slot
+            </Header>
+          }
+        >
+          <ColumnLayout columns={3} variant="text-grid">
+            <Box>
+              <Box variant="awsui-key-label">Status</Box>
+              <Box>{slot_status.bootloader_0.status}</Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">Build Date</Box>
+              <Box>{slot_status.bootloader_0.bundle_build}</Box>
+            </Box>
+            <Box>
+              <Box variant="awsui-key-label">Installation Date</Box>
+              <Box>{slot_status.bootloader_0.installed_timestamp}</Box>
+            </Box>
+          </ColumnLayout>
         </Container>
       </SpaceBetween>
     );

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -240,6 +240,28 @@ export function ProgressNotification() {
   );
 }
 
+export function RebootNotification() {
+  const should_reboot = useMqttSubscription<boolean>(
+    "/v1/tac/update/should_reboot"
+  );
+
+  return (
+    <Alert
+      statusIconAriaLabel="Info"
+      visible={should_reboot === true}
+      action={
+        <MqttButton iconName="refresh" topic="/v1/tac/reboot" send={true}>
+          Reboot
+        </MqttButton>
+      }
+      header="Reboot into other slot"
+    >
+      There is a newer operating system bundle installed in the other boot slot.
+      Reboot now to use it.
+    </Alert>
+  );
+}
+
 export function UpdateContainer() {
   return (
     <Container

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -17,6 +17,7 @@
 
 import { useEffect, useState, useRef } from "react";
 
+import Alert from "@cloudscape-design/components/alert";
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
@@ -317,5 +318,24 @@ export function RaucContainer() {
         <RaucSlotStatus />
       </SpaceBetween>
     </Container>
+  );
+}
+
+export function LocatorNotification() {
+  const locator = useMqttSubscription<boolean>("/v1/tac/display/locator");
+
+  return (
+    <Alert
+      statusIconAriaLabel="Info"
+      visible={locator === true}
+      action={
+        <MqttButton topic="/v1/tac/display/locator" send={false}>
+          Found it!
+        </MqttButton>
+      }
+      header="Find this TAC"
+    >
+      Someone is looking for this TAC.
+    </Alert>
   );
 }

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -91,7 +91,7 @@ enum RaucInstallStep {
   Done,
 }
 
-export function RaucSlotStatus() {
+export function SlotStatus() {
   const slot_status = useMqttSubscription<RaucSlots>("/v1/tac/update/slots");
 
   if (slot_status === undefined) {
@@ -301,7 +301,7 @@ export function RaucInstall() {
   );
 }
 
-export function RaucContainer() {
+export function UpdateContainer() {
   return (
     <Container
       header={
@@ -315,7 +315,7 @@ export function RaucContainer() {
     >
       <SpaceBetween size="m">
         <RaucInstall />
-        <RaucSlotStatus />
+        <SlotStatus />
       </SpaceBetween>
     </Container>
   );


### PR DESCRIPTION
This PR adds operating system update handling to the tacd.

What this means from an users point of view:

1. Periodic polling of the enabled update channels found a new update available for installation:
    ![upgrade](https://user-images.githubusercontent.com/1273320/237062787-a1d06a3e-2af0-4b83-80bc-f439e1ce3b18.png)
2. The user clicks "Install" on on either the web interface, the local display or via a `rauc install …` call on the commandline:
    ![installing](https://user-images.githubusercontent.com/1273320/237062822-b88161a3-2240-467e-86f5-4a5bd1f0d2e7.png)
3. Once the installation is complete a note urging the user to reboot is shown:
    ![reboot](https://user-images.githubusercontent.com/1273320/237062842-7fbd9757-a32d-444b-8df4-cd2aede45b20.png)

The necessity to display new alerts/notifications on the local screen (Update available, Installing, Please Reboot) kicked up quite some dust in the `src/ui/*` part of the code, which is why a lot of commits happened there.
With these changes it is now (among other improvements) possible to have multiple active alerts/notifications at the same time and a concept of priorities on which should be shown first between them.

Related Pull Requests
----------------------------

- [ ] If an update channel is enabled/disabled is checked via the existence of certificate files. These files are introduced in linux-automation/meta-lxatac#37. If the file paths or names in that PR change this one may have to be updated accordingly.