### PR TITLE
web: MqttComponents: Snap MqttChart y-axis dimensions to a list of fixed values

### DIFF
--- a/web/src/DashboardDut.tsx
+++ b/web/src/DashboardDut.tsx
@@ -103,11 +103,17 @@ export default function DashboardDut() {
         <ColumnLayout columns={2} variant="text-grid">
           <Box>
             <Box variant="awsui-key-label">DUT voltage (V)</Box>
-            <MqttChart topic="/v1/dut/feedback/voltage" />
+            <MqttChart
+              title="DUT Voltage"
+              topic="/v1/dut/feedback/voltage"
+            />
           </Box>
           <Box>
             <Box variant="awsui-key-label">DUT current (A)</Box>
-            <MqttChart topic="/v1/dut/feedback/current" />
+            <MqttChart
+              title="DUT Current"
+              topic="/v1/dut/feedback/current"
+            />
           </Box>
         </ColumnLayout>
         <ColumnLayout columns={4} variant="text-grid">
@@ -239,7 +245,10 @@ export default function DashboardDut() {
                 additionalInfo="The absolute voltage is independent of pin orientation"
               />
               <UnloadingSection header={`OUT_${port} voltage plot (V)`}>
-                <MqttChart topic={`/v1/output/out_${port}/feedback/voltage`} />
+                <MqttChart
+                  title={`OUT_${port} Voltage`}
+                  topic={`/v1/output/out_${port}/feedback/voltage`}
+                />
               </UnloadingSection>
             </SpaceBetween>
           </ColumnLayout>
@@ -304,7 +313,10 @@ export default function DashboardDut() {
               additionalInfo="Too many devices may overload the bus"
             />
             <UnloadingSection header="IOBus current plot">
-              <MqttChart topic="/v1/iobus/feedback/current" />
+              <MqttChart
+                title="IOBus current"
+                topic="/v1/iobus/feedback/current"
+              />
             </UnloadingSection>
             <MqttBarMeter
               topic="/v1/iobus/feedback/voltage"
@@ -318,7 +330,10 @@ export default function DashboardDut() {
               additionalInfo="The voltage will go down if the bus is overloaded"
             />
             <UnloadingSection header="IOBus voltage plot">
-              <MqttChart topic="/v1/iobus/feedback/voltage" />
+              <MqttChart
+                title="IOBus current"
+                topic="/v1/iobus/feedback/voltage"
+              />
             </UnloadingSection>
           </SpaceBetween>
         </ColumnLayout>
@@ -380,6 +395,7 @@ export default function DashboardDut() {
                   />
                   <UnloadingSection header={`USB Port ${port} current plot`}>
                     <MqttChart
+                      title={`Port ${port} current`}
                       topic={`/v1/usb/host/port${port}/feedback/current`}
                     />
                   </UnloadingSection>

--- a/web/src/DashboardDut.tsx
+++ b/web/src/DashboardDut.tsx
@@ -106,6 +106,8 @@ export default function DashboardDut() {
             <MqttChart
               title="DUT Voltage"
               topic="/v1/dut/feedback/voltage"
+              maxSnapPoints={[6, 13, 25, 50]}
+              minSnapPoints={[-1]}
             />
           </Box>
           <Box>
@@ -113,6 +115,8 @@ export default function DashboardDut() {
             <MqttChart
               title="DUT Current"
               topic="/v1/dut/feedback/current"
+              maxSnapPoints={[0.5, 1, 2, 3, 4, 5]}
+              minSnapPoints={[-0.1, -1]}
             />
           </Box>
         </ColumnLayout>
@@ -248,6 +252,8 @@ export default function DashboardDut() {
                 <MqttChart
                   title={`OUT_${port} Voltage`}
                   topic={`/v1/output/out_${port}/feedback/voltage`}
+                  maxSnapPoints={[4, 6]}
+                  minSnapPoints={[-4, -6]}
                 />
               </UnloadingSection>
             </SpaceBetween>
@@ -316,6 +322,8 @@ export default function DashboardDut() {
               <MqttChart
                 title="IOBus current"
                 topic="/v1/iobus/feedback/current"
+                maxSnapPoints={[0.25]}
+                minSnapPoints={[0]}
               />
             </UnloadingSection>
             <MqttBarMeter
@@ -333,6 +341,8 @@ export default function DashboardDut() {
               <MqttChart
                 title="IOBus current"
                 topic="/v1/iobus/feedback/voltage"
+                maxSnapPoints={[13]}
+                minSnapPoints={[0]}
               />
             </UnloadingSection>
           </SpaceBetween>
@@ -397,6 +407,8 @@ export default function DashboardDut() {
                     <MqttChart
                       title={`Port ${port} current`}
                       topic={`/v1/usb/host/port${port}/feedback/current`}
+                      maxSnapPoints={[0.5]}
+                      minSnapPoints={[0]}
                     />
                   </UnloadingSection>
                 </SpaceBetween>

--- a/web/src/MqttComponents.tsx
+++ b/web/src/MqttComponents.tsx
@@ -262,6 +262,8 @@ function measToPoint(m: Measurement) {
 interface MqttChartProps {
   title: string;
   topic: string;
+  maxSnapPoints: Array<number>;
+  minSnapPoints: Array<number>;
 }
 
 export function MqttChart(props: MqttChartProps) {
@@ -271,6 +273,26 @@ export function MqttChart(props: MqttChartProps) {
     measToPoint,
   );
   let values = history.current;
+
+  // Find y-axis snap points that are smaller/larger than all samples in view.
+  let minSnap = 0;
+  let maxSnap = 0;
+
+  for (let i = 0; i < values.length; i++) {
+    while (
+      minSnap < props.minSnapPoints.length - 1 &&
+      values[i]["y"] < props.minSnapPoints[minSnap]
+    ) {
+      minSnap++;
+    }
+
+    while (
+      maxSnap < props.maxSnapPoints.length - 1 &&
+      values[i]["y"] > props.maxSnapPoints[maxSnap]
+    ) {
+      maxSnap++;
+    }
+  }
 
   let end = values.length >= 1 ? values[values.length - 1]["x"] : new Date();
 
@@ -291,6 +313,7 @@ export function MqttChart(props: MqttChartProps) {
             ((Number(e) - Number(end)) / 1000).toFixed(1) + "s",
         }}
         height={200}
+        yDomain={[props.minSnapPoints[minSnap], props.maxSnapPoints[maxSnap]]}
         hideFilter
         hideLegend
       />

--- a/web/src/MqttComponents.tsx
+++ b/web/src/MqttComponents.tsx
@@ -260,6 +260,7 @@ function measToPoint(m: Measurement) {
 }
 
 interface MqttChartProps {
+  title: string;
   topic: string;
 }
 
@@ -275,7 +276,7 @@ export function MqttChart(props: MqttChartProps) {
 
   let series: MixedLineBarChartProps.ChartSeries<Date> = {
     type: "line",
-    title: "eh",
+    title: props.title,
     data: values,
   };
 


### PR DESCRIPTION
As of now the y-Axis auto-scales to match the values in the plot. This means it expands the axis to arbitrarily small values, making
every bit of ADC noise look huge (even though it isn't).

Specify explicit ranges to snap to instead. The selected values are not completely random. The DUT voltage ranges for example are choosen just above typical supply voltages (5V, 12V, 24V, 48V).

Without this PR (simulated but somewhat realistic values):
![without](https://github.com/linux-automation/tacd/assets/1273320/40a39617-2b8c-4a90-88a4-653589689fcf)

With this PR (simulated but somewhat realistic values):
![with](https://github.com/linux-automation/tacd/assets/1273320/7e4898fd-017a-4aea-99bc-4beadb5625ee)
