### PR TITLE
regulators: change regulator names to those in new devicetrees

### DIFF
--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -75,8 +75,8 @@ fn handle_regulator(
 impl Regulators {
     pub fn new(bb: &mut BrokerBuilder) -> Self {
         Self {
-            iobus_pwr_en: handle_regulator(bb, "/v1/iobus/powered", "output_iobus_12v", true),
-            uart_pwr_en: handle_regulator(bb, "/v1/uart/powered", "output_vuart", true),
+            iobus_pwr_en: handle_regulator(bb, "/v1/iobus/powered", "output-iobus-12v", true),
+            uart_pwr_en: handle_regulator(bb, "/v1/uart/powered", "output-vuart", true),
         }
     }
 }


### PR DESCRIPTION
The regulator names with underscores instead of dashes do not match the schema that should be used in upstream devicetrees.

Related Pull Requests
---------------

This PR depends on the following other PRs which require coordination:

- [ ] The `meta-lxatac` PR that changes the regulator names to the ones used here linux-automation/meta-lxatac#45.