### PR TITLE
adc: iio: hardware: add buffering support to the powerboard ADC

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -78,11 +78,12 @@ pub struct Adc {
 
 impl Adc {
     pub async fn new(bb: &mut BrokerBuilder) -> Result<Self> {
-        let iio_thread = IioThread::new().await?;
+        let stm32_thread = IioThread::new_stm32().await?;
+        let powerboard_thread = IioThread::new_powerboard().await?;
 
         let adc = Self {
             usb_host_curr: AdcChannel {
-                fast: iio_thread.clone().get_channel("usb-host-curr").unwrap(),
+                fast: stm32_thread.clone().get_channel("usb-host-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/usb/host/total/feedback/current",
                     true,
@@ -93,7 +94,7 @@ impl Adc {
                 ),
             },
             usb_host1_curr: AdcChannel {
-                fast: iio_thread.clone().get_channel("usb-host1-curr").unwrap(),
+                fast: stm32_thread.clone().get_channel("usb-host1-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/usb/host/port1/feedback/current",
                     true,
@@ -104,7 +105,7 @@ impl Adc {
                 ),
             },
             usb_host2_curr: AdcChannel {
-                fast: iio_thread.clone().get_channel("usb-host2-curr").unwrap(),
+                fast: stm32_thread.clone().get_channel("usb-host2-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/usb/host/port2/feedback/current",
                     true,
@@ -115,7 +116,7 @@ impl Adc {
                 ),
             },
             usb_host3_curr: AdcChannel {
-                fast: iio_thread.clone().get_channel("usb-host3-curr").unwrap(),
+                fast: stm32_thread.clone().get_channel("usb-host3-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/usb/host/port3/feedback/current",
                     true,
@@ -126,7 +127,7 @@ impl Adc {
                 ),
             },
             out0_volt: AdcChannel {
-                fast: iio_thread.clone().get_channel("out0-volt").unwrap(),
+                fast: stm32_thread.clone().get_channel("out0-volt").unwrap(),
                 topic: bb.topic(
                     "/v1/output/out_0/feedback/voltage",
                     true,
@@ -137,7 +138,7 @@ impl Adc {
                 ),
             },
             out1_volt: AdcChannel {
-                fast: iio_thread.clone().get_channel("out1-volt").unwrap(),
+                fast: stm32_thread.clone().get_channel("out1-volt").unwrap(),
                 topic: bb.topic(
                     "/v1/output/out_1/feedback/voltage",
                     true,
@@ -148,7 +149,7 @@ impl Adc {
                 ),
             },
             iobus_curr: AdcChannel {
-                fast: iio_thread.clone().get_channel("iobus-curr").unwrap(),
+                fast: stm32_thread.clone().get_channel("iobus-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/iobus/feedback/current",
                     true,
@@ -159,7 +160,7 @@ impl Adc {
                 ),
             },
             iobus_volt: AdcChannel {
-                fast: iio_thread.clone().get_channel("iobus-volt").unwrap(),
+                fast: stm32_thread.clone().get_channel("iobus-volt").unwrap(),
                 topic: bb.topic(
                     "/v1/iobus/feedback/voltage",
                     true,
@@ -170,7 +171,7 @@ impl Adc {
                 ),
             },
             pwr_volt: AdcChannel {
-                fast: iio_thread.clone().get_channel("pwr-volt").unwrap(),
+                fast: powerboard_thread.clone().get_channel("pwr-volt").unwrap(),
                 topic: bb.topic(
                     "/v1/dut/feedback/voltage",
                     true,
@@ -181,7 +182,7 @@ impl Adc {
                 ),
             },
             pwr_curr: AdcChannel {
-                fast: iio_thread.get_channel("pwr-curr").unwrap(),
+                fast: powerboard_thread.get_channel("pwr-curr").unwrap(),
                 topic: bb.topic(
                     "/v1/dut/feedback/current",
                     true,

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -98,18 +98,18 @@ impl CalibratedChannel {
     pub fn try_get_multiple<const N: usize>(
         &self,
         channels: [&Self; N],
-    ) -> Option<[Measurement; N]> {
+    ) -> Result<[Measurement; N]> {
         let ts = Timestamp::now();
         let mut results = [Measurement { ts, value: 0.0 }; N];
 
         for i in 0..N {
-            results[i].value = channels[i].get().value;
+            results[i].value = channels[i].get().unwrap().value;
         }
 
-        Some(results)
+        Ok(results)
     }
 
-    pub fn get(&self) -> Measurement {
+    pub fn get(&self) -> Result<Measurement> {
         let ts = Timestamp::now();
 
         let dt = {
@@ -135,13 +135,13 @@ impl CalibratedChannel {
             .inner
             .parents
             .iter()
-            .map(|p| p.get().value)
+            .map(|p| p.get().unwrap().value)
             .sum::<f32>();
         value += nominal;
 
         self.inner.value.store(value.to_bits(), Ordering::Relaxed);
 
-        Measurement { ts, value }
+        Ok(Measurement { ts, value })
     }
 
     pub fn set(&self, state: bool) {

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -16,11 +16,13 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use std::convert::{TryFrom, TryInto};
+use std::fs::create_dir;
 use std::io::Read;
+use std::path::Path;
 use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::thread;
-use std::thread::{sleep, JoinHandle};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Error, Result};
@@ -101,6 +103,8 @@ const CHANNELS_PWR: &[ChannelDesc] = &[
         name: "pwr-curr",
     },
 ];
+
+const TRIGGER_HR_PWR_DIR: &str = "/sys/kernel/config/iio/triggers/hrtimer/tacd-pwr";
 
 const TIMESTAMP_ERROR: u64 = u64::MAX;
 
@@ -243,7 +247,13 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    fn adc_setup_stm32() -> Result<(Vec<Channel>, Buffer)> {
+    fn adc_setup(
+        adc_name: &str,
+        trigger_name: &str,
+        sample_rate: i64,
+        channel_descs: &[ChannelDesc],
+        buffer_len: usize,
+    ) -> Result<(Vec<Channel>, Buffer)> {
         let ctx = industrial_io::Context::new()?;
 
         debug!("IIO devices:");
@@ -251,20 +261,20 @@ impl IioThread {
             debug!("  * {}", &dev.name().unwrap_or_default());
         }
 
-        let stm32_adc = ctx
-            .find_device("48003000.adc:adc@0")
-            .ok_or(anyhow!("Could not find STM32 ADC"))?;
+        let adc = ctx
+            .find_device(adc_name)
+            .ok_or(anyhow!("Could not find ADC: {}", adc_name))?;
 
-        if let Err(err) = stm32_adc.attr_write_bool("buffer/enable", false) {
-            warn!("Failed to disable STM32 ADC buffer: {}", err);
+        if let Err(err) = adc.attr_write_bool("buffer/enable", false) {
+            warn!("Failed to disable {} ADC buffer: {}", adc_name, err);
         }
 
-        let stm32_channels: Vec<Channel> = CHANNELS_STM32
+        let channels: Vec<Channel> = channel_descs
             .iter()
             .map(|ChannelDesc { kernel_name, .. }| {
-                let ch = stm32_adc
+                let ch = adc
                     .find_channel(kernel_name, false)
-                    .unwrap_or_else(|| panic!("Failed to open iio channel {}", kernel_name));
+                    .unwrap_or_else(|| panic!("Failed to open kernel channel {}", kernel_name));
 
                 ch.enable();
                 ch
@@ -272,14 +282,15 @@ impl IioThread {
             .collect();
 
         let trig = ctx
-            .find_device("tim4_trgo")
-            .ok_or(anyhow!("Could not find STM32 Timer 4 trigger"))?;
-        trig.attr_write_int("sampling_frequency", 1024)?;
+            .find_device(trigger_name)
+            .ok_or(anyhow!("Could not find IIO trigger: {}", trigger_name))?;
 
-        stm32_adc.set_trigger(&trig)?;
+        trig.attr_write_int("sampling_frequency", sample_rate)?;
+
+        adc.set_trigger(&trig)?;
         ctx.set_timeout_ms(1000)?;
 
-        let stm32_buf = stm32_adc.create_buffer(128, false)?;
+        let buf = adc.create_buffer(buffer_len, false)?;
 
         set_thread_priority_and_policy(
             thread_native_id(),
@@ -288,10 +299,17 @@ impl IioThread {
         )
         .map_err(|e| anyhow!("Failed to set realtime thread priority: {e:?}"))?;
 
-        Ok((stm32_channels, stm32_buf))
+        Ok((channels, buf))
     }
 
-    pub async fn new_stm32() -> Result<Arc<Self>> {
+    async fn new(
+        thread_name: &str,
+        adc_name: &'static str,
+        trigger_name: &'static str,
+        sample_rate: i64,
+        channel_descs: &'static [ChannelDesc],
+        buffer_len: usize,
+    ) -> Result<Arc<Self>> {
         // Some of the adc thread setup can only happen _in_ the adc thread,
         // like setting the priority or some iio setup, as not all structs
         // are Send.
@@ -303,16 +321,23 @@ impl IioThread {
 
         // Spawn a high priority thread that updates the atomic values in `thread`.
         let join = thread::Builder::new()
-            .name("tacd stm32 iio".to_string())
+            .name(format!("tacd {thread_name} iio"))
             .spawn(move || {
-                let (thread, channels, mut buf) = match Self::adc_setup_stm32() {
+                let adc_setup_res = Self::adc_setup(
+                    adc_name,
+                    trigger_name,
+                    sample_rate,
+                    channel_descs,
+                    buffer_len,
+                );
+                let (thread, channels, mut buf) = match adc_setup_res {
                     Ok((channels, buf)) => {
                         let thread = Arc::new(Self {
                             ref_instant: Instant::now(),
                             timestamp: AtomicU64::new(TIMESTAMP_ERROR),
                             values: channels.iter().map(|_| AtomicU16::new(0)).collect(),
                             join: Mutex::new(None),
-                            channel_descs: CHANNELS_STM32,
+                            channel_descs,
                         });
 
                         (thread, channels, buf)
@@ -332,7 +357,7 @@ impl IioThread {
                     if let Err(e) = buf.refill() {
                         thread.timestamp.store(TIMESTAMP_ERROR, Ordering::Relaxed);
 
-                        error!("Failed to refill stm32 ADC buffer: {}", e);
+                        error!("Failed to refill {} ADC buffer: {}", adc_name, e);
 
                         // If the ADC has not yet produced any values we still have the
                         // queue at hand that signals readiness to the main thread.
@@ -377,127 +402,26 @@ impl IioThread {
         Ok(thread)
     }
 
-    fn adc_setup_powerboard() -> Result<Vec<Channel>> {
-        let ctx = industrial_io::Context::new()?;
-
-        debug!("IIO devices:");
-        for dev in ctx.devices() {
-            debug!("  * {}", &dev.name().unwrap_or_default());
-        }
-
-        let pwr_adc = ctx
-            .find_device("lmp92064")
-            .ok_or(anyhow!("Could not find Powerboard ADC"))?;
-
-        ctx.set_timeout_ms(1000)?;
-
-        let pwr_channels: Vec<Channel> = CHANNELS_PWR
-            .iter()
-            .map(|ChannelDesc { kernel_name, .. }| {
-                pwr_adc
-                    .find_channel(kernel_name, false)
-                    .unwrap_or_else(|| panic!("Failed to open iio channel {}", kernel_name))
-            })
-            .collect();
-
-        set_thread_priority_and_policy(
-            thread_native_id(),
-            ThreadPriority::Crossplatform(ThreadPriorityValue::try_from(10).unwrap()),
-            ThreadSchedulePolicy::Realtime(RealtimeThreadSchedulePolicy::Fifo),
+    pub async fn new_stm32() -> Result<Arc<Self>> {
+        Self::new(
+            "stm32",
+            "48003000.adc:adc@0",
+            "tim4_trgo",
+            1024,
+            CHANNELS_STM32,
+            128,
         )
-        .map_err(|e| anyhow!("Failed to set realtime thread priority: {e:?}"))?;
-
-        Ok(pwr_channels)
+        .await
     }
 
     pub async fn new_powerboard() -> Result<Arc<Self>> {
-        // Some of the adc thread setup can only happen _in_ the adc thread,
-        // like setting the priority or some iio setup, as not all structs
-        // are Send.
-        // We do however not want to return from new() before we know that the
-        // setup was sucessful.
-        // This is why we create Self inside the thread and send it back
-        // to the calling thread via a queue.
-        let (thread_res_tx, mut thread_res_rx) = bounded(1);
+        let hr_trigger_path = Path::new(TRIGGER_HR_PWR_DIR);
 
-        // Spawn a high priority thread that updates the atomic values in `thread`.
-        let join = thread::Builder::new()
-            .name("tacd powerboard iio".to_string())
-            .spawn(move || {
-                let (thread, channels) = match Self::adc_setup_powerboard() {
-                    Ok(channels) => {
-                        let thread = Arc::new(Self {
-                            ref_instant: Instant::now(),
-                            timestamp: AtomicU64::new(TIMESTAMP_ERROR),
-                            values: channels.iter().map(|_| AtomicU16::new(0)).collect(),
-                            join: Mutex::new(None),
-                            channel_descs: CHANNELS_PWR,
-                        });
+        if !hr_trigger_path.is_dir() {
+            create_dir(hr_trigger_path).unwrap();
+        }
 
-                        (thread, channels)
-                    }
-                    Err(e) => {
-                        thread_res_tx.try_send(Err(e)).unwrap();
-                        return;
-                    }
-                };
-
-                let thread_weak = Arc::downgrade(&thread);
-                let mut signal_ready = Some((thread, thread_res_tx));
-
-                // Stop running as soon as the last reference to this Arc<IioThread>
-                // is dropped (e.g. the weak reference can no longer be upgraded).
-                while let Some(thread) = thread_weak.upgrade() {
-                    // Use the sysfs based interface to get the values from the
-                    // power board ADC at a slow sampling rate.
-                    let voltage = channels[0].attr_read_int("raw");
-                    let current = channels[1].attr_read_int("raw");
-
-                    let (voltage, current) = match (voltage, current) {
-                        (Ok(v), Ok(c)) => (v, c),
-                        (Err(e), _) | (_, Err(e)) => {
-                            thread.timestamp.store(TIMESTAMP_ERROR, Ordering::Relaxed);
-
-                            error!("Failed to read Powerboard ADC: {}", e);
-
-                            // If the ADC has not yet produced any values we still have the
-                            // queue at hand that signals readiness to the main thread.
-                            // This gives us a chance to return an Err from new().
-                            // If the queue was already used just print an error instead.
-                            if let Some((_, tx)) = signal_ready.take() {
-                                tx.try_send(Err(Error::new(e))).unwrap();
-                            }
-
-                            break;
-                        }
-                    };
-
-                    thread.values[0].store(voltage as u16, Ordering::Relaxed);
-                    thread.values[1].store(current as u16, Ordering::Relaxed);
-
-                    let ts: u64 = Instant::now()
-                        .checked_duration_since(thread.ref_instant)
-                        .unwrap()
-                        .as_nanos()
-                        .try_into()
-                        .unwrap();
-
-                    thread.timestamp.store(ts, Ordering::Release);
-
-                    // Now that we know that the ADC actually works and we have
-                    // initial values: return a handle to it.
-                    if let Some((content, tx)) = signal_ready.take() {
-                        tx.try_send(Ok(content)).unwrap();
-                    }
-
-                    sleep(Duration::from_millis(50));
-                }
-            })?;
-
-        let thread = thread_res_rx.next().await.unwrap()?;
-        *thread.join.lock().unwrap() = Some(join);
-
-        Ok(thread)
+        Self::new("powerboard", "lmp92064", "tacd-pwr", 20, CHANNELS_PWR, 1).await
     }
 
     /// Use the channel names defined at the top of the file to get a reference

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -407,9 +407,9 @@ impl IioThread {
             "stm32",
             "48003000.adc:adc@0",
             "tim4_trgo",
-            1024,
+            80,
             CHANNELS_STM32,
-            128,
+            4,
         )
         .await
     }

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -25,7 +25,7 @@ use crate::measurement::{Measurement, Timestamp};
 
 const NO_TRANSIENT: u32 = u32::MAX;
 
-const CHANNELS: &[&str] = &[
+const CHANNELS_STM32: &[&str] = &[
     "usb-host-curr",
     "usb-host1-curr",
     "usb-host2-curr",
@@ -34,9 +34,9 @@ const CHANNELS: &[&str] = &[
     "out1-volt",
     "iobus-curr",
     "iobus-volt",
-    "pwr-volt",
-    "pwr-curr",
 ];
+
+const CHANNELS_PWR: &[&str] = &["pwr-volt", "pwr-curr"];
 
 #[derive(Clone)]
 pub struct CalibratedChannel {
@@ -111,10 +111,20 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    pub async fn new() -> Result<Arc<Self>> {
+    pub async fn new_stm32() -> Result<Arc<Self>> {
         let mut channels = Vec::new();
 
-        for name in CHANNELS {
+        for name in CHANNELS_STM32 {
+            channels.push((*name, CalibratedChannel::new()))
+        }
+
+        Ok(Arc::new(Self { channels }))
+    }
+
+    pub async fn new_powerboard() -> Result<Arc<Self>> {
+        let mut channels = Vec::new();
+
+        for name in CHANNELS_PWR {
             channels.push((*name, CalibratedChannel::new()))
         }
 

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -57,7 +57,7 @@ impl CalibratedChannel {
     pub fn try_get_multiple<const N: usize>(
         &self,
         channels: [&Self; N],
-    ) -> Option<[Measurement; N]> {
+    ) -> Result<[Measurement; N]> {
         let mut ts = Timestamp::now();
 
         if self.stall.load(Ordering::Relaxed) {
@@ -78,19 +78,15 @@ impl CalibratedChannel {
             results[i].value = f32::from_bits(val_u32);
         }
 
-        Some(results)
+        Ok(results)
     }
 
-    pub fn try_get(&self) -> Option<Measurement> {
+    pub fn try_get(&self) -> Result<Measurement> {
         self.try_get_multiple([self]).map(|res| res[0])
     }
 
-    pub fn get(&self) -> Measurement {
-        loop {
-            if let Some(r) = self.try_get() {
-                break r;
-            }
-        }
+    pub fn get(&self) -> Result<Measurement> {
+        self.try_get()
     }
 
     pub fn set(&self, val: f32) {

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -30,18 +30,28 @@ impl LineHandle {
         // It is just a hack to let adc/iio/demo_mode.rs
         // communicate with this function so that toggling an output
         // has an effect on the measured values.
-        let iio_thread = block_on(IioThread::new()).unwrap();
+        let iio_thread_stm32 = block_on(IioThread::new_stm32()).unwrap();
+        let iio_thread_pwr = block_on(IioThread::new_powerboard()).unwrap();
 
         match self.name.as_str() {
-            "OUT_0" => iio_thread.get_channel("out0-volt").unwrap().set(val != 0),
-            "OUT_1" => iio_thread.get_channel("out1-volt").unwrap().set(val != 0),
+            "OUT_0" => iio_thread_stm32
+                .get_channel("out0-volt")
+                .unwrap()
+                .set(val != 0),
+            "OUT_1" => iio_thread_stm32
+                .get_channel("out1-volt")
+                .unwrap()
+                .set(val != 0),
             "DUT_PWR_EN" => {
-                iio_thread
+                iio_thread_pwr
                     .clone()
                     .get_channel("pwr-curr")
                     .unwrap()
                     .set(val == 0);
-                iio_thread.get_channel("pwr-volt").unwrap().set(val == 0);
+                iio_thread_pwr
+                    .get_channel("pwr-volt")
+                    .unwrap()
+                    .set(val == 0);
             }
             _ => {}
         }

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -353,7 +353,12 @@ impl DutPwrThread {
                             .fast
                             .try_get_multiple([&pwr_volt.fast, &pwr_curr.fast]);
 
-                        if let Some(m) = feedback {
+                        // We do not care too much about _why_ we could not get
+                        // a new value from the ADC.
+                        // If we get a new valid value before the timeout we
+                        // are fine.
+                        // If not we are not.
+                        if let Ok(m) = feedback {
                             last_ts = Some(m[0].ts.as_instant());
                         }
 
@@ -374,7 +379,7 @@ impl DutPwrThread {
                             tick.fetch_add(1, Ordering::Relaxed);
                         }
 
-                        if let Some(m) = feedback {
+                        if let Ok(m) = feedback {
                             break (m[0].value, m[1].value);
                         }
                     };

--- a/src/iobus.rs
+++ b/src/iobus.rs
@@ -142,10 +142,12 @@ impl IoBus {
                 let current = iobus_curr.get();
                 let voltage = iobus_volt.get();
 
-                let undervolt = pwr_en && (voltage.value < VOLTAGE_MIN);
-                let overcurrent = current.value > CURRENT_MAX;
+                if let (Ok(current), Ok(voltage)) = (current, voltage) {
+                    let undervolt = pwr_en && (voltage.value < VOLTAGE_MIN);
+                    let overcurrent = current.value > CURRENT_MAX;
 
-                supply_fault_task.set_if_changed(undervolt || overcurrent);
+                    supply_fault_task.set_if_changed(undervolt || overcurrent);
+                }
 
                 sleep(Duration::from_secs(1)).await;
             }

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -31,7 +31,7 @@ mod reg {
 
     pub fn regulator_set(name: &str, state: bool) -> Result<()> {
         if name == "output_iobus_12v" {
-            let iio_thread = block_on(IioThread::new()).unwrap();
+            let iio_thread = block_on(IioThread::new_stm32()).unwrap();
 
             iio_thread
                 .clone()

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -92,7 +92,7 @@ mod rw {
 
         for (path_tail, iio_channel) in DISABLE_CHANNELS {
             if path.ends_with(path_tail) {
-                let iio_thread = block_on(IioThread::new()).unwrap();
+                let iio_thread = block_on(IioThread::new_stm32()).unwrap();
 
                 iio_thread
                     .get_channel(iio_channel)


### PR DESCRIPTION
This PR adds buffering support to the powerboard ADC. The main benefit of this change is that voltage and current samples are now taken at the exact same point int time, enabling better instantaneous power measurements.

This feature relies on kernel support for buffering in the powerboard ADC and a fix to `libiio` to allow enabling the buffer for the ADC, both of which are not currently included in `meta-lxatac`.

Related Pull Requests
----------

- [ ] The `meta-lxatac` PR that coordinates the kernel and libiio update, as well as adding this feature linux-automation/meta-lxatac#47