### PR TITLE
iobus: display power supply overload notifications  

### DIFF
--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -15,10 +15,6 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::iter::Iterator;
-use std::thread::sleep;
-use std::time::Duration;
-
 use anyhow::Result;
 use async_std::task::block_on;
 
@@ -54,49 +50,9 @@ impl LineHandle {
     }
 }
 
-pub struct LineEvent(u8);
-
-impl LineEvent {
-    pub fn event_type(&self) -> EventType {
-        match self.0 {
-            0 => EventType::FallingEdge,
-            _ => EventType::RisingEdge,
-        }
-    }
-}
-
-pub struct LineEventHandle {}
-
-impl LineEventHandle {
-    pub fn get_value(&self) -> Result<u8, ()> {
-        Ok(0)
-    }
-}
-
-impl Iterator for LineEventHandle {
-    type Item = Result<LineEvent, ()>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            sleep(Duration::from_secs(1000));
-        }
-    }
-}
-
-pub enum EventType {
-    RisingEdge,
-    FallingEdge,
-}
-
-#[allow(non_camel_case_types)]
-pub enum EventRequestFlags {
-    BOTH_EDGES,
-}
-
 #[allow(clippy::upper_case_acronyms)]
 pub enum LineRequestFlags {
     OUTPUT,
-    INPUT,
 }
 
 pub struct FindDecoy {
@@ -112,15 +68,6 @@ impl FindDecoy {
         line_handle.set_value(initial).unwrap();
 
         Ok(line_handle)
-    }
-
-    pub fn events(
-        &self,
-        _: LineRequestFlags,
-        _: EventRequestFlags,
-        _: &str,
-    ) -> Result<LineEventHandle, ()> {
-        Ok(LineEventHandle {})
     }
 }
 

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -39,14 +39,6 @@ impl LineHandle {
         match self.name.as_str() {
             "OUT_0" => iio_thread.get_channel("out0-volt").unwrap().set(val != 0),
             "OUT_1" => iio_thread.get_channel("out1-volt").unwrap().set(val != 0),
-            "IOBUS_PWR_EN" => {
-                iio_thread
-                    .clone()
-                    .get_channel("iobus-curr")
-                    .unwrap()
-                    .set(val != 0);
-                iio_thread.get_channel("iobus-volt").unwrap().set(val != 0);
-            }
             "DUT_PWR_EN" => {
                 iio_thread
                     .clone()

--- a/src/digital_io/gpio/test.rs
+++ b/src/digital_io/gpio/test.rs
@@ -41,24 +41,9 @@ impl LineHandle {
 
 pub struct LineEvent(u8);
 
-impl LineEvent {
-    pub fn event_type(&self) -> EventType {
-        match self.0 {
-            0 => EventType::FallingEdge,
-            _ => EventType::RisingEdge,
-        }
-    }
-}
-
 pub struct LineEventHandle {
     val: Arc<AtomicU8>,
     prev_val: u8,
-}
-
-impl LineEventHandle {
-    pub fn get_value(&self) -> Result<u8, ()> {
-        Ok(self.val.load(Ordering::Relaxed))
-    }
 }
 
 impl Iterator for LineEventHandle {
@@ -78,20 +63,9 @@ impl Iterator for LineEventHandle {
     }
 }
 
-pub enum EventType {
-    RisingEdge,
-    FallingEdge,
-}
-
-#[allow(non_camel_case_types)]
-pub enum EventRequestFlags {
-    BOTH_EDGES,
-}
-
 #[allow(clippy::upper_case_acronyms)]
 pub enum LineRequestFlags {
     OUTPUT,
-    INPUT,
 }
 
 pub struct FindDecoy {
@@ -106,18 +80,6 @@ impl FindDecoy {
         Ok(LineHandle {
             name: self.name.clone(),
             val: self.val.clone(),
-        })
-    }
-
-    pub fn events(
-        &self,
-        _: LineRequestFlags,
-        _: EventRequestFlags,
-        _: &str,
-    ) -> Result<LineEventHandle> {
-        Ok(LineEventHandle {
-            val: self.val.clone(),
-            prev_val: self.val.load(Ordering::Relaxed),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,12 @@ async fn main() -> Result<(), std::io::Error> {
 
     // Expose other software on the TAC via the broker framework by connecting
     // to them via HTTP / DBus APIs.
-    let iobus = IoBus::new(&mut bb);
+    let iobus = IoBus::new(
+        &mut bb,
+        regulators.iobus_pwr_en.clone(),
+        adc.iobus_curr.fast.clone(),
+        adc.iobus_volt.fast.clone(),
+    );
     let (network, rauc, systemd) = {
         let dbus = DbusSession::new(&mut bb, led.eth_dut.clone(), led.eth_lab.clone()).await;
 

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -25,7 +25,22 @@ use crate::broker::{BrokerBuilder, Topic};
 mod reg {
     use std::io::Result;
 
+    use async_std::task::block_on;
+
+    use crate::adc::IioThread;
+
     pub fn regulator_set(name: &str, state: bool) -> Result<()> {
+        if name == "output_iobus_12v" {
+            let iio_thread = block_on(IioThread::new()).unwrap();
+
+            iio_thread
+                .clone()
+                .get_channel("iobus-curr")
+                .unwrap()
+                .set(state);
+            iio_thread.get_channel("iobus-volt").unwrap().set(state);
+        }
+
         let state = if state { "enabled" } else { "disabled" };
         println!("Regulator: would set {name} to {state} but don't feel like it");
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -29,6 +29,7 @@ use serde::{Deserialize, Serialize};
 mod dig_out;
 mod help;
 mod iobus;
+mod iobus_health;
 mod locator;
 mod power;
 mod reboot;
@@ -43,6 +44,7 @@ mod usb;
 use dig_out::DigOutScreen;
 use help::HelpScreen;
 use iobus::IoBusScreen;
+use iobus_health::IoBusHealthScreen;
 use locator::LocatorScreen;
 use power::PowerScreen;
 use reboot::RebootConfirmScreen;
@@ -75,6 +77,7 @@ pub enum NormalScreen {
 #[derive(Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Debug)]
 pub enum AlertScreen {
     ScreenSaver,
+    IoBusHealth,
     Locator,
     RebootConfirm,
     UpdateAvailable,
@@ -185,6 +188,7 @@ pub(super) fn init(
         Box::new(UartScreen::new()),
         Box::new(UsbScreen::new()),
         Box::new(HelpScreen::new(alerts, &res.setup_mode.show_help)),
+        Box::new(IoBusHealthScreen::new(alerts, &res.iobus.supply_fault)),
         Box::new(UpdateInstallationScreen::new(
             alerts,
             &res.rauc.operation,

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -111,7 +111,7 @@ impl ActivatableScreen for IoBusScreen {
 
         widgets.push(|display| {
             DynamicWidget::indicator(
-                ui.res.dig_io.iobus_flt_fb.clone(),
+                ui.res.iobus.supply_fault.clone(),
                 display,
                 row_anchor(2) + OFFSET_INDICATOR,
                 Box::new(|state: &bool| match *state {

--- a/src/ui/screens/iobus_health.rs
+++ b/src/ui/screens/iobus_health.rs
@@ -1,0 +1,137 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+use async_trait::async_trait;
+use embedded_graphics::{
+    mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
+};
+
+use super::widgets::*;
+use super::{
+    row_anchor, ActivatableScreen, ActiveScreen, AlertList, AlertScreen, Alerter, Display,
+    InputEvent, Screen, Ui,
+};
+use crate::broker::Topic;
+use crate::measurement::Measurement;
+
+const SCREEN_TYPE: AlertScreen = AlertScreen::IoBusHealth;
+
+pub struct IoBusHealthScreen;
+
+struct Active {
+    widgets: WidgetContainer,
+    alerts: Arc<Topic<AlertList>>,
+}
+
+impl IoBusHealthScreen {
+    pub fn new(alerts: &Arc<Topic<AlertList>>, supply_fault: &Arc<Topic<bool>>) -> Self {
+        let (mut supply_fault_events, _) = supply_fault.clone().subscribe_unbounded();
+        let alerts = alerts.clone();
+
+        spawn(async move {
+            while let Some(fault) = supply_fault_events.next().await {
+                if fault {
+                    alerts.assert(SCREEN_TYPE);
+                } else {
+                    alerts.deassert(SCREEN_TYPE);
+                }
+            }
+        });
+
+        Self
+    }
+}
+
+impl ActivatableScreen for IoBusHealthScreen {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        let ui_text_style: MonoTextStyle<BinaryColor> =
+            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+        display.with_lock(|target| {
+            Text::new(
+                "IOBus supply overload",
+                row_anchor(0) - (row_anchor(1) - row_anchor(0)),
+                ui_text_style,
+            )
+            .draw(target)
+            .unwrap();
+
+            Text::new(
+                "The IOBus supply is\noverloaded by a short\nor too many devices.",
+                row_anchor(1),
+                ui_text_style,
+            )
+            .draw(target)
+            .unwrap();
+
+            Text::new("> Dismiss", row_anchor(8), ui_text_style)
+                .draw(target)
+                .unwrap();
+        });
+
+        let mut widgets = WidgetContainer::new(display);
+
+        widgets.push(|display| {
+            DynamicWidget::text(
+                ui.res.adc.iobus_volt.topic.clone(),
+                display,
+                row_anchor(5),
+                Box::new(|meas: &Measurement| format!("  {:-6.2}V /  12V", meas.value)),
+            )
+        });
+
+        widgets.push(|display| {
+            DynamicWidget::text(
+                ui.res.adc.iobus_curr.topic.clone(),
+                display,
+                row_anchor(6),
+                Box::new(|meas: &Measurement| format!("  {:-6.2}A / 0.2A", meas.value)),
+            )
+        });
+
+        let alerts = ui.alerts.clone();
+
+        Box::new(Active { widgets, alerts })
+    }
+}
+
+#[async_trait]
+impl ActiveScreen for Active {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.widgets.destroy().await
+    }
+
+    fn input(&mut self, ev: InputEvent) {
+        match ev {
+            InputEvent::NextScreen | InputEvent::ToggleAction(_) => {}
+            InputEvent::PerformAction(_) => {
+                self.alerts.deassert(SCREEN_TYPE);
+            }
+        }
+    }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import "./App.css";
 import { useMqttSubscription } from "./mqtt";
 import { ApiPickerButton, MqttButton } from "./MqttComponents";
 import {
+  IOBusFaultNotification,
   RebootNotification,
   UpdateNotification,
   ProgressNotification,
@@ -158,6 +159,7 @@ function Notifications() {
       <ProgressNotification />
       <UpdateNotification />
       <LocatorNotification />
+      <IOBusFaultNotification />
     </>
   );
 }

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -487,3 +487,19 @@ export function LocatorNotification() {
     </Alert>
   );
 }
+
+export function IOBusFaultNotification() {
+  const overload = useMqttSubscription<boolean>("/v1/iobus/feedback/fault");
+
+  return (
+    <Alert
+      statusIconAriaLabel="Warning"
+      type="warning"
+      visible={overload === true}
+      header="The IOBus power supply is overloaded"
+    >
+      The power supply on the IOBus connector is either shorted or overloaded by
+      too many devices on the bus.
+    </Alert>
+  );
+}


### PR DESCRIPTION
This should make troubleshooting easier in case of a short-circuit or overload on the IOBus bus.

![IOBus fault](https://github.com/linux-automation/tacd/assets/1273320/8861c392-58f6-40b3-aaf0-95bfaf7a778c)

Related Pull Requests
----------

- [x] The `tacd` PR that fixes `prettier` autoformatting for the web interface code #30 