### PR TITLE
dut_power: make GPIOs open drain

### DIFF
--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -81,8 +81,8 @@ impl FindDecoy {
     }
 }
 
-pub fn find_line(name: &str) -> Result<FindDecoy> {
-    Ok(FindDecoy {
+pub fn find_line(name: &str) -> Option<FindDecoy> {
+    Some(FindDecoy {
         name: name.to_string(),
     })
 }

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -15,6 +15,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use std::ops::BitOr;
+
 use anyhow::Result;
 use async_std::task::block_on;
 
@@ -60,9 +62,30 @@ impl LineHandle {
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub enum LineRequestFlags {
     OUTPUT,
+    OPEN_DRAIN,
+}
+
+impl BitOr for LineRequestFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::OPEN_DRAIN, res) | (res, Self::OPEN_DRAIN) => res,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct ChipDecoy;
+
+impl ChipDecoy {
+    pub fn label(&self) -> &'static str {
+        "demo_mode"
+    }
 }
 
 pub struct FindDecoy {
@@ -78,6 +101,10 @@ impl FindDecoy {
         line_handle.set_value(initial).unwrap();
 
         Ok(line_handle)
+    }
+
+    pub fn chip(&self) -> ChipDecoy {
+        ChipDecoy
     }
 }
 

--- a/src/digital_io/gpio/test.rs
+++ b/src/digital_io/gpio/test.rs
@@ -16,6 +16,7 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use std::iter::Iterator;
+use std::ops::BitOr;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
@@ -63,9 +64,30 @@ impl Iterator for LineEventHandle {
     }
 }
 
-#[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+#[derive(Clone, Copy)]
 pub enum LineRequestFlags {
     OUTPUT,
+    OPEN_DRAIN,
+}
+
+impl BitOr for LineRequestFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Self::OPEN_DRAIN, res) | (res, Self::OPEN_DRAIN) => res,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct ChipDecoy;
+
+impl ChipDecoy {
+    pub fn label(&self) -> &'static str {
+        "test"
+    }
 }
 
 pub struct FindDecoy {
@@ -81,6 +103,10 @@ impl FindDecoy {
             name: self.name.clone(),
             val: self.val.clone(),
         })
+    }
+
+    pub fn chip(&self) -> ChipDecoy {
+        ChipDecoy
     }
 
     pub fn stub_get(&self) -> u8 {

--- a/src/digital_io/gpio/test.rs
+++ b/src/digital_io/gpio/test.rs
@@ -88,7 +88,7 @@ impl FindDecoy {
     }
 }
 
-pub fn find_line(name: &str) -> Result<FindDecoy> {
+pub fn find_line(name: &str) -> Option<FindDecoy> {
     let val = {
         let mut lines = block_on(LINES.lock());
 
@@ -101,7 +101,7 @@ pub fn find_line(name: &str) -> Result<FindDecoy> {
         }
     };
 
-    Ok(FindDecoy {
+    Some(FindDecoy {
         name: name.to_string(),
         val,
     })


### PR DESCRIPTION
This PR improves the EMI performance of the TAC (at least when measuring the emissions on pins of the IOBus port in isolation).

How can that be you ask? The `VCC_IO` supply line powering all of the SoC's GPIO pins is necessarily affected by high frequency switching of e.g. the RGMII and eMMC lines. This results in GPIOs that are actively driven high also containing said noise.
This PR makes it so that the lines are never driven high by the SoC, relying instead on pull-up resistors on the power board.

But the `DUT_PWR_EN` and `DUT_PWR_DISCH` don't leave the device, they only go to the flat flex connector to the power board, I hear you ask. How can they couple out of the IOBus connector?
It looks like the noise couples onto the IOBus signal lines that are right next to the GPIOs on the flat flex connector.

Fun times were had figuring that out.