### PR TITLE
 usb: display power supply overload notifications

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -272,6 +272,22 @@ paths:
               schema:
                 $ref: '#/components/schemas/UsbDevice'
 
+  /v1/usb/host/overload:
+    get:
+      summary: Get the name of the currently overloaded port (if any)
+      tags: [USB Host]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+                enum:
+                  - Total
+                  - Port1
+                  - Port2
+                  - Port3
+
   /v1/tac/temperatures/soc:
     get:
       summary: Get the current temperature inside the SoC

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -128,8 +128,14 @@ impl CalibratedChannel {
 
         let mut value = f32::from_bits(self.inner.value.load(Ordering::Relaxed));
 
+        let decay = if time_constant.abs() < 0.01 {
+            0.0
+        } else {
+            (-dt / time_constant).exp()
+        };
+
         value -= nominal;
-        value *= (-dt / time_constant).exp();
+        value *= decay;
         value += (2.0 * thread_rng().gen::<f32>() - 1.0) * self.inner.noise;
         value += self
             .inner

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,13 @@ async fn main() -> Result<()> {
     let dig_io = DigitalIo::new(&mut bb, led.out_0.clone(), led.out_1.clone());
     let regulators = Regulators::new(&mut bb);
     let temperatures = Temperatures::new(&mut bb);
-    let usb_hub = UsbHub::new(&mut bb);
+    let usb_hub = UsbHub::new(
+        &mut bb,
+        adc.usb_host_curr.fast.clone(),
+        adc.usb_host1_curr.fast.clone(),
+        adc.usb_host2_curr.fast.clone(),
+        adc.usb_host3_curr.fast.clone(),
+    );
 
     // Expose other software on the TAC via the broker framework by connecting
     // to them via HTTP / DBus APIs.

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -41,6 +41,7 @@ mod uart;
 mod update_available;
 mod update_installation;
 mod usb;
+mod usb_overload;
 
 use dig_out::DigOutScreen;
 use help::HelpScreen;
@@ -57,6 +58,7 @@ use uart::UartScreen;
 use update_available::UpdateAvailableScreen;
 use update_installation::UpdateInstallationScreen;
 use usb::UsbScreen;
+use usb_overload::UsbOverloadScreen;
 
 use super::buttons;
 use super::widgets;
@@ -84,6 +86,7 @@ pub enum AlertScreen {
     RebootConfirm,
     UpdateAvailable,
     UpdateInstallation,
+    UsbOverload,
     Help,
     Setup,
     OverTemperature,
@@ -207,5 +210,6 @@ pub(super) fn init(
             &res.temperatures.warning,
         )),
         Box::new(LocatorScreen::new(alerts, locator)),
+        Box::new(UsbOverloadScreen::new(alerts, &res.usb_hub.overload)),
     ]
 }

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -28,10 +28,9 @@ use super::{
 };
 use crate::broker::Topic;
 use crate::measurement::Measurement;
+use crate::usb_hub::{MAX_PORT_CURRENT, MAX_TOTAL_CURRENT};
 
 const SCREEN_TYPE: NormalScreen = NormalScreen::Usb;
-const CURRENT_LIMIT_PER_PORT: f32 = 0.5;
-const CURRENT_LIMIT_TOTAL: f32 = 0.7;
 const OFFSET_INDICATOR: Point = Point::new(92, -10);
 const OFFSET_BAR: Point = Point::new(122, -14);
 const WIDTH_BAR: u32 = 90;
@@ -103,7 +102,7 @@ impl ActivatableScreen for UsbScreen {
                 row_anchor(0) + OFFSET_BAR,
                 WIDTH_BAR,
                 HEIGHT_BAR,
-                Box::new(|meas: &Measurement| meas.value / CURRENT_LIMIT_TOTAL),
+                Box::new(|meas: &Measurement| meas.value / MAX_TOTAL_CURRENT),
             )
         });
 
@@ -143,7 +142,7 @@ impl ActivatableScreen for UsbScreen {
                     anchor_bar,
                     WIDTH_BAR,
                     HEIGHT_BAR,
-                    Box::new(|meas: &Measurement| meas.value / CURRENT_LIMIT_PER_PORT),
+                    Box::new(|meas: &Measurement| meas.value / MAX_PORT_CURRENT),
                 )
             });
         }

--- a/src/ui/screens/usb_overload.rs
+++ b/src/ui/screens/usb_overload.rs
@@ -1,0 +1,150 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2023 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use async_std::prelude::*;
+use async_std::sync::Arc;
+use async_std::task::spawn;
+use async_trait::async_trait;
+use embedded_graphics::{
+    mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
+};
+
+use super::widgets::*;
+use super::{
+    row_anchor, ActivatableScreen, ActiveScreen, AlertList, AlertScreen, Alerter, Display,
+    InputEvent, Screen, Ui,
+};
+use crate::broker::Topic;
+use crate::measurement::Measurement;
+use crate::usb_hub::{OverloadedPort, MAX_PORT_CURRENT, MAX_TOTAL_CURRENT};
+
+const SCREEN_TYPE: AlertScreen = AlertScreen::UsbOverload;
+const OFFSET_BAR: Point = Point::new(75, -14);
+const OFFSET_VAL: Point = Point::new(160, 0);
+const WIDTH_BAR: u32 = 80;
+const HEIGHT_BAR: u32 = 18;
+
+pub struct UsbOverloadScreen;
+
+struct Active {
+    widgets: WidgetContainer,
+}
+
+impl UsbOverloadScreen {
+    pub fn new(
+        alerts: &Arc<Topic<AlertList>>,
+        overload: &Arc<Topic<Option<OverloadedPort>>>,
+    ) -> Self {
+        let (mut overload_events, _) = overload.clone().subscribe_unbounded();
+        let alerts = alerts.clone();
+
+        spawn(async move {
+            while let Some(overload) = overload_events.next().await {
+                if overload.is_some() {
+                    alerts.assert(SCREEN_TYPE)
+                } else {
+                    alerts.deassert(SCREEN_TYPE)
+                }
+            }
+        });
+
+        Self
+    }
+}
+
+impl ActivatableScreen for UsbOverloadScreen {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        let ui_text_style: MonoTextStyle<BinaryColor> =
+            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
+
+        display.with_lock(|target| {
+            Text::new(
+                "USB Power Overload",
+                row_anchor(0) - (row_anchor(1) - row_anchor(0)),
+                ui_text_style,
+            )
+            .draw(target)
+            .unwrap();
+
+            Text::new(
+                "Disconnect devices or\nuse a powered hub.",
+                row_anchor(1),
+                ui_text_style,
+            )
+            .draw(target)
+            .unwrap();
+
+            for (row, name) in &[(4, "Total"), (6, "Port 1"), (7, "Port 2"), (8, "Port 3")] {
+                Text::new(name, row_anchor(*row), ui_text_style)
+                    .draw(target)
+                    .unwrap();
+            }
+        });
+
+        let mut widgets = WidgetContainer::new(display);
+
+        let ports = [
+            (0, &ui.res.adc.usb_host_curr.topic, MAX_TOTAL_CURRENT),
+            (2, &ui.res.adc.usb_host1_curr.topic, MAX_PORT_CURRENT),
+            (3, &ui.res.adc.usb_host2_curr.topic, MAX_PORT_CURRENT),
+            (4, &ui.res.adc.usb_host3_curr.topic, MAX_PORT_CURRENT),
+        ];
+
+        for (idx, current, max_current) in ports {
+            let anchor_port = row_anchor(idx + 4);
+
+            widgets.push(|display| {
+                DynamicWidget::bar(
+                    current.clone(),
+                    display,
+                    anchor_port + OFFSET_BAR,
+                    WIDTH_BAR,
+                    HEIGHT_BAR,
+                    Box::new(move |meas: &Measurement| meas.value / max_current),
+                )
+            });
+
+            widgets.push(|display| {
+                DynamicWidget::text(
+                    current.clone(),
+                    display,
+                    anchor_port + OFFSET_VAL,
+                    Box::new(|meas: &Measurement| format!("{:>4.0}mA", meas.value * 1000.0)),
+                )
+            });
+        }
+
+        Box::new(Active { widgets })
+    }
+}
+
+#[async_trait]
+impl ActiveScreen for Active {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.widgets.destroy().await
+    }
+
+    fn input(&mut self, _ev: InputEvent) {}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
   ProgressNotification,
   LocatorNotification,
   OverTemperatureNotification,
+  UsbOverloadNotification,
 } from "./TacComponents";
 
 function Navigation() {
@@ -159,6 +160,7 @@ function Notifications() {
       <RebootNotification />
       <OverTemperatureNotification />
       <ProgressNotification />
+      <UsbOverloadNotification />
       <UpdateNotification />
       <LocatorNotification />
       <IOBusFaultNotification />

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -89,6 +89,13 @@ enum RaucInstallStep {
   Done,
 }
 
+enum UsbOverload {
+  Total = "Total",
+  Port1 = "Port1",
+  Port2 = "Port2",
+  Port3 = "Port3",
+}
+
 type Duration = {
   secs: number;
   nanos: number;
@@ -517,6 +524,42 @@ export function OverTemperatureNotification() {
       The LXA TAC's temperature is{" "}
       {warning === "SocCritical" ? "critical" : "high"}. Provide better airflow
       and check for overloads!
+    </Alert>
+  );
+}
+
+export function UsbOverloadNotification() {
+  const overload = useMqttSubscription<UsbOverload | null>(
+    "/v1/usb/host/overload",
+  );
+
+  let header = "One of the USB host ports is overloaded";
+  let detail = "";
+
+  switch (overload) {
+    case UsbOverload.Total:
+      header = "The USB host ports are overloaded";
+      detail = "devices";
+      break;
+    case UsbOverload.Port1:
+      detail = "the device from port 1";
+      break;
+    case UsbOverload.Port2:
+      detail = "the device from port 2";
+      break;
+    case UsbOverload.Port3:
+      detail = "the device from port 3";
+      break;
+  }
+
+  return (
+    <Alert
+      statusIconAriaLabel="Warning"
+      type="warning"
+      visible={overload !== null}
+      header={header}
+    >
+      Disconnect {detail} or use a powered hub to resolve this issue.
     </Alert>
   );
 }


### PR DESCRIPTION
Add warning on the LCD …

![lcd](https://github.com/linux-automation/tacd/assets/1273320/95288f6d-73df-466a-9217-cff40a23fbfc)

… and web interface if the LXA TAC' USB ports are overloaded.

![web](https://github.com/linux-automation/tacd/assets/1273320/7bbbd6ac-83f7-4c9a-ae22-425315c2f88a)
