### PR TITLE
tacd: show message on screen if hardware setup failed

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -35,6 +35,7 @@ mod widgets;
 use alerts::{AlertList, Alerter};
 use buttons::{handle_buttons, Button, ButtonEvent, Direction, PressDuration, Source};
 pub use display::{Display, ScreenShooter};
+pub use screens::message;
 use screens::{splash, ActivatableScreen, AlertScreen, NormalScreen, Screen};
 
 pub struct UiResources {

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -170,7 +170,10 @@ pub fn message(target: &mut DisplayExclusive, text: &str) -> Rectangle {
     let ui_text_style: MonoTextStyle<BinaryColor> =
         MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-    let text = Text::with_alignment(text, Point::new(120, 120), ui_text_style, Alignment::Center);
+    let mut text = Text::with_alignment(text, Point::zero(), ui_text_style, Alignment::Center);
+
+    let offset = Point::new(120, 120) - text.bounding_box().center();
+    text.translate_mut(offset);
 
     text.draw(target).unwrap();
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -166,20 +166,19 @@ const fn row_anchor(row_num: u8) -> Point {
     Point::new(8, 52 + (row_num as i32) * 20)
 }
 
-pub(super) fn splash(target: &mut DisplayExclusive) -> Rectangle {
+pub fn message(target: &mut DisplayExclusive, text: &str) -> Rectangle {
     let ui_text_style: MonoTextStyle<BinaryColor> =
         MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
-    let text = Text::with_alignment(
-        "Welcome",
-        Point::new(120, 120),
-        ui_text_style,
-        Alignment::Center,
-    );
+    let text = Text::with_alignment(text, Point::new(120, 120), ui_text_style, Alignment::Center);
 
     text.draw(target).unwrap();
 
     text.bounding_box()
+}
+
+pub fn splash(target: &mut DisplayExclusive) -> Rectangle {
+    message(target, "Welcome")
 }
 
 pub(super) fn init(


### PR DESCRIPTION
As of now the `tacd` prints a "Welcome!" message on the LCD and then goes on to setting up the remaining hardware units.
If the setup of any of the peripherals fails the `tacd` just crashes and no message is printed on the LCD to inform the user.

Instead print a generic (and thus not too helpful message) to give some indication of what is going on:

![errs](https://github.com/linux-automation/tacd/assets/1273320/7e0cc439-b407-45fc-bf0a-4e9682e5f30e)

We can not fit much more on the screen, so the user has to check the systemd journal if the actually want to know what's wrong.

TODO before merging:

- [x] Test on actual hardware