### PR TITLE
rauc: only consider good slots for update and reboot notifications

### DIFF
--- a/src/dbus/rauc/update_channels.rs
+++ b/src/dbus/rauc/update_channels.rs
@@ -194,12 +194,14 @@ impl UpstreamBundle {
     pub(super) fn update_install(&mut self, slot_status: &SlotStatus) {
         let slot_0_is_older = slot_status
             .get("rootfs_0")
+            .filter(|r| r.get("boot_status").map_or(false, |b| b == "good"))
             .and_then(|r| r.get("bundle_version"))
             .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
             .unwrap_or(true);
 
         let slot_1_is_older = slot_status
             .get("rootfs_1")
+            .filter(|r| r.get("boot_status").map_or(false, |b| b == "good"))
             .and_then(|r| r.get("bundle_version"))
             .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
             .unwrap_or(true);


### PR DESCRIPTION
Fix two issues regarding notifications and RAUC slots:

- If the not-booted slot is marked as bad, either due to too many boot failures or manual intervention, it should not be considered when displaying _"there_ is a newer OS image in the other boot slot, reboot to use it"_ messages, as rebooting will indeed not use it.
- A bad image in the other slot should also not be considered when determining if an update is available¹.

TODO before merging:

- [x] Test on hardware in different bundle configurations
- [x] Determine if ¹ is actually true. If we have the same image in a slot marked as bad and on the server the image on the server is likely bad and we should maybe skip the image.