### PR TITLE
web: mqtt: set all topics to null instead of undefined on connection loss

### DIFF
--- a/web/src/mqtt.ts
+++ b/web/src/mqtt.ts
@@ -24,7 +24,7 @@ export const session = new Client(
 );
 
 let subscriptions: {
-  [topic: string]: Array<(message: Message | undefined) => void>;
+  [topic: string]: Array<(message: Message | null) => void>;
 } = {};
 
 let retained: {
@@ -37,7 +37,7 @@ session.onConnectionLost = function (responseObject) {
 
     for (let topic in subscriptions) {
       for (let handler of subscriptions[topic]) {
-        handler(undefined);
+        handler(null);
       }
     }
 
@@ -64,10 +64,7 @@ session.connect({
   reconnect: true,
 });
 
-function subscribe(
-  topic: string,
-  handleMessage: (m: Message | undefined) => void,
-) {
+function subscribe(topic: string, handleMessage: (m: Message | null) => void) {
   if (subscriptions[topic] === undefined) {
     if (session.isConnected()) {
       session.subscribe(topic);
@@ -105,8 +102,8 @@ export function useMqttState<T>(topic: string, initial?: T) {
   ]);
 
   useEffect(() => {
-    function handleMessage(message: Message | undefined) {
-      if (message !== undefined) {
+    function handleMessage(message: Message | null) {
+      if (message !== null) {
         setShadow([true, JSON.parse(message.payloadString)]);
       } else {
         setShadow([false, undefined]);
@@ -155,8 +152,8 @@ export function useMqttHistory<T, M>(
   useEffect(() => {
     let priv_hist: Array<M> = [];
 
-    function handleMessage(message: Message | undefined) {
-      if (message !== undefined) {
+    function handleMessage(message: Message | null) {
+      if (message !== null) {
         let msg_json = JSON.parse(message.payloadString);
         let msg_conv = format(msg_json);
         priv_hist.push(msg_conv);


### PR DESCRIPTION
This came up when running a tacd with #32 applied on real hardware¹ and power-cycling the device (resulting in a disconnect):

![conn_loss](https://github.com/linux-automation/tacd/assets/1273320/d9f95954-84ce-40c9-b373-582e07631f76)

The notification components added in this PRs check MQTT topics for a non-`null` value to decide if the warning should be shown, but the disconnect handler sets it to `undefined` instead:

https://github.com/linux-automation/tacd/blob/bdeb3fae1b59000d46efbdc117a49bbd9bf42d2b/web/src/TacComponents.tsx#L523-L528

As far as I can tell a value that is intentionally left blank should be `null` and not `undefined` (which implies an error in the program).

Change the disconnect handler to reflect that.

TODO before merging:

- [ ] Check if this change causes issues elsewhere

---

-¹ The over temperature warning that is shown as well is due to a similar issue in #33 that should however be fixed there.