### PR TITLE
ci: tacd: use only cargo clippy and not cargo check as well

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -14,30 +14,6 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
-  check:
-    strategy:
-      matrix:
-        features:
-          - ""
-          - "--features=demo_mode --no-default-features"
-          - "--tests"
-    name: cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt update
-      - run: sudo apt install libsystemd-dev libiio-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: ${{ matrix.features }}
-
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest


### PR DESCRIPTION
The checks performed by running cargo check are a subset of what cargo clippy checks for (as indicated by cargo clippy [using cargo check in the background]):

https://github.com/rust-lang/rust-clippy/blob/c154754b74577906c5d55d57f7daeff02d6a33e7/src/main.rs#L59-L105

Running both is thus a waste of CPU cycles. Run cargo clippy only.
