### PR TITLE
tacd: set appropriate pub(super) scopes for demo mode import hacks

### DIFF
--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -22,25 +22,25 @@ use crate::led::BlinkPattern;
 
 #[cfg(feature = "demo_mode")]
 mod zb {
-    pub type Result<T> = std::result::Result<T, ()>;
+    pub(super) type Result<T> = std::result::Result<T, ()>;
 
     pub struct Connection;
     pub struct ConnectionBuilder;
 
     impl ConnectionBuilder {
-        pub fn system() -> Result<Self> {
+        pub(super) fn system() -> Result<Self> {
             Ok(Self)
         }
 
-        pub fn name(self, _: &'static str) -> Result<Self> {
+        pub(super) fn name(self, _: &'static str) -> Result<Self> {
             Ok(self)
         }
 
-        pub fn serve_at<T>(self, _: &'static str, _: T) -> Result<Self> {
+        pub(super) fn serve_at<T>(self, _: &'static str, _: T) -> Result<Self> {
             Ok(self)
         }
 
-        pub async fn build(self) -> Result<Connection> {
+        pub(super) async fn build(self) -> Result<Connection> {
             Ok(Connection)
         }
     }
@@ -48,7 +48,8 @@ mod zb {
 
 #[cfg(not(feature = "demo_mode"))]
 mod zb {
-    pub use zbus::*;
+    pub(super) use zbus::Result;
+    pub use zbus::{Connection, ConnectionBuilder};
 }
 
 use zb::{Connection, ConnectionBuilder, Result};

--- a/src/dbus/networkmanager/mod.rs
+++ b/src/dbus/networkmanager/mod.rs
@@ -28,17 +28,17 @@ mod hostname;
 
 // All of the following includes are not used in demo_mode.
 // Put them inside a mod so we do not have to decorate each one with
-// a #[cfg(not(feature = "demo_mode"))].
+#[cfg(not(feature = "demo_mode"))]
 mod optional_includes {
-    pub use anyhow::{anyhow, Result};
-    pub use async_std::stream::StreamExt;
-    pub use async_std::task::sleep;
-    pub use futures::{future::FutureExt, pin_mut, select};
-    pub use log::trace;
-    pub use std::convert::TryInto;
-    pub use std::time::Duration;
-    pub use zbus::{Connection, PropertyStream};
-    pub use zvariant::{ObjectPath, OwnedObjectPath};
+    pub(super) use anyhow::{anyhow, Result};
+    pub(super) use async_std::stream::StreamExt;
+    pub(super) use async_std::task::sleep;
+    pub(super) use futures::{future::FutureExt, pin_mut, select};
+    pub(super) use log::trace;
+    pub(super) use std::convert::TryInto;
+    pub(super) use std::time::Duration;
+    pub(super) use zbus::{Connection, PropertyStream};
+    pub(super) use zvariant::{ObjectPath, OwnedObjectPath};
 }
 
 #[cfg(not(feature = "demo_mode"))]

--- a/src/dbus/rauc/mod.rs
+++ b/src/dbus/rauc/mod.rs
@@ -43,7 +43,7 @@ use installer::InstallerProxy;
 
 #[cfg(feature = "demo_mode")]
 mod imports {
-    pub struct InstallerProxy<'a> {
+    pub(super) struct InstallerProxy<'a> {
         _dummy: &'a (),
     }
 
@@ -60,16 +60,15 @@ mod imports {
         }
     }
 
-    pub const CHANNELS_DIR: &str = "demo_files/usr/share/tacd/update_channels";
+    pub(super) const CHANNELS_DIR: &str = "demo_files/usr/share/tacd/update_channels";
 }
 
 #[cfg(not(feature = "demo_mode"))]
 mod imports {
-    pub use anyhow::{anyhow, bail, Result};
-    pub use futures::FutureExt;
-    pub use log::error;
+    pub(super) use anyhow::{anyhow, bail, Result};
+    pub(super) use log::error;
 
-    pub const CHANNELS_DIR: &str = "/usr/share/tacd/update_channels";
+    pub(super) const CHANNELS_DIR: &str = "/usr/share/tacd/update_channels";
 }
 
 const RELOAD_RATE_LIMIT: Duration = Duration::from_secs(10 * 60);

--- a/src/iobus.rs
+++ b/src/iobus.rs
@@ -32,9 +32,9 @@ const VOLTAGE_MIN: f32 = 10.0;
 mod http {
     use super::{LSSState, Nodes, ServerInfo};
 
-    pub struct RequestDecoy {}
+    pub(super) struct RequestDecoy {}
 
-    pub trait DemoModeDefault {
+    pub(super) trait DemoModeDefault {
         fn demo_get() -> Self;
     }
 
@@ -62,19 +62,19 @@ mod http {
     }
 
     impl RequestDecoy {
-        pub async fn recv_json<T: DemoModeDefault>(&self) -> Result<T, ()> {
+        pub(super) async fn recv_json<T: DemoModeDefault>(&self) -> Result<T, ()> {
             Ok(T::demo_get())
         }
     }
 
-    pub fn get(_: &str) -> RequestDecoy {
+    pub(super) fn get(_: &str) -> RequestDecoy {
         RequestDecoy {}
     }
 }
 
 #[cfg(not(feature = "demo_mode"))]
 mod http {
-    pub use surf::get;
+    pub(super) use surf::get;
 }
 
 #[derive(PartialEq, Serialize, Deserialize, Debug, Clone)]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -28,14 +28,14 @@ use tide::{Request, Response, Server};
 #[cfg(any(test, feature = "demo_mode"))]
 mod sd {
     use std::collections::btree_map::BTreeMap;
-    pub use std::io::Result;
+    pub(super) use std::io::Result;
     use std::io::{Error, ErrorKind};
     use std::thread::sleep;
     use std::time::{Duration, SystemTime};
 
-    pub type JournalRecord = BTreeMap<String, String>;
-    pub struct Journal;
-    pub struct OpenOptions;
+    pub(super) type JournalRecord = BTreeMap<String, String>;
+    pub(super) struct Journal;
+    pub(super) struct OpenOptions;
 
     impl OpenOptions {
         pub fn default() -> Self {
@@ -88,8 +88,8 @@ mod sd {
 
 #[cfg(not(any(test, feature = "demo_mode")))]
 mod sd {
-    pub use systemd::journal::*;
-    pub use systemd::*;
+    pub(super) use systemd::journal::*;
+    pub(super) use systemd::*;
 }
 
 use sd::{Journal, JournalRecord, OpenOptions, Result};

--- a/src/temperatures.rs
+++ b/src/temperatures.rs
@@ -28,12 +28,12 @@ use crate::measurement::Measurement;
 
 #[cfg(feature = "demo_mode")]
 mod hw {
-    pub trait SysClass {
+    pub(super) trait SysClass {
         fn input(&self) -> Result<u32, ()>;
     }
 
-    pub struct HwMon;
-    pub struct TempDecoy;
+    pub(super) struct HwMon;
+    pub(super) struct TempDecoy;
 
     impl SysClass for TempDecoy {
         fn input(&self) -> Result<u32, ()> {
@@ -42,11 +42,11 @@ mod hw {
     }
 
     impl HwMon {
-        pub fn new(_: &'static str) -> Result<Self, ()> {
+        pub(super) fn new(_: &'static str) -> Result<Self, ()> {
             Ok(Self)
         }
 
-        pub fn temp(&self, _: u64) -> Result<TempDecoy, ()> {
+        pub(super) fn temp(&self, _: u64) -> Result<TempDecoy, ()> {
             Ok(TempDecoy)
         }
     }
@@ -54,7 +54,7 @@ mod hw {
 
 #[cfg(not(feature = "demo_mode"))]
 mod hw {
-    pub use sysfs_class::*;
+    pub(super) use sysfs_class::*;
 }
 
 use hw::{HwMon, SysClass};

--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -28,9 +28,9 @@ pub const LONG_PRESS: Duration = Duration::from_millis(500);
 #[cfg(feature = "demo_mode")]
 mod evd {
     use evdev::FetchEventsSynced;
-    pub use evdev::{EventType, InputEventKind, Key};
+    pub(super) use evdev::{EventType, InputEventKind, Key};
 
-    pub struct Device {}
+    pub(super) struct Device {}
 
     impl Device {
         pub fn open(_path: &'static str) -> Result<Self, ()> {
@@ -47,7 +47,7 @@ mod evd {
 
 #[cfg(not(feature = "demo_mode"))]
 mod evd {
-    pub use evdev::*;
+    pub(super) use evdev::*;
 }
 
 use evd::{Device, EventType, InputEventKind, Key};

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -25,7 +25,7 @@ use png::{BitDepth, ColorType, Encoder};
 mod backend {
     use framebuffer::{FixScreeninfo, VarScreeninfo};
 
-    pub struct Framebuffer {
+    pub(super) struct Framebuffer {
         pub device: (),
         pub var_screen_info: VarScreeninfo,
         pub fix_screen_info: FixScreeninfo,
@@ -58,7 +58,7 @@ mod backend {
 
 #[cfg(not(feature = "demo_mode"))]
 mod backend {
-    pub use framebuffer::*;
+    pub(super) use framebuffer::*;
 }
 
 use backend::Framebuffer;

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -61,7 +61,7 @@ mod rw {
 
     static FILESYSTEM: Mutex<Option<HashMap<String, String>>> = Mutex::new(None);
 
-    pub fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
+    pub(super) fn read_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
         let path = path.as_ref().to_str().unwrap();
 
         if let Some(stored) = FILESYSTEM
@@ -83,7 +83,7 @@ mod rw {
         Ok("0".to_string())
     }
 
-    pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
+    pub(super) fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Result<()> {
         let path: &Path = path.as_ref();
         let path = path.to_str().unwrap().to_string();
         let contents: &[u8] = contents.as_ref();
@@ -114,7 +114,7 @@ mod rw {
 
 #[cfg(not(feature = "demo_mode"))]
 mod rw {
-    pub use std::fs::*;
+    pub(super) use std::fs::*;
 }
 
 use rw::{read_to_string, write};

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -26,21 +26,21 @@ use crate::dut_power::TickReader;
 mod sd {
     use std::io::Result;
 
-    pub const STATE_READY: () = ();
-    pub const STATE_WATCHDOG: () = ();
+    pub(super) const STATE_READY: () = ();
+    pub(super) const STATE_WATCHDOG: () = ();
 
-    pub fn notify<I>(_: bool, _: I) -> Result<bool> {
+    pub(super) fn notify<I>(_: bool, _: I) -> Result<bool> {
         Ok(true)
     }
 
-    pub fn watchdog_enabled(_: bool) -> Result<u64> {
+    pub(super) fn watchdog_enabled(_: bool) -> Result<u64> {
         Ok(5_000_000)
     }
 }
 
 #[cfg(not(any(test, feature = "demo_mode")))]
 mod sd {
-    pub use systemd::daemon::*;
+    pub(super) use systemd::daemon::*;
 }
 
 use sd::{notify, watchdog_enabled, STATE_READY, STATE_WATCHDOG};


### PR DESCRIPTION
This makes sure we get dead code warnings about unused imports, which we do not get when using the global `pub`.

Also fix said warnings that came up.