### PR TITLE
watched_tasks: maintain a list of spawned async tasks and propagate errors

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -227,7 +227,7 @@ impl Adc {
 
                 time.set(Timestamp::now());
             }
-        });
+        })?;
 
         Ok(adc)
     }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -79,8 +79,8 @@ pub struct Adc {
 
 impl Adc {
     pub async fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Result<Self> {
-        let stm32_thread = IioThread::new_stm32().await?;
-        let powerboard_thread = IioThread::new_powerboard().await?;
+        let stm32_thread = IioThread::new_stm32(wtb).await?;
+        let powerboard_thread = IioThread::new_powerboard(wtb).await?;
 
         let adc = Self {
             usb_host_curr: AdcChannel {

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -160,7 +160,7 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    pub async fn new_stm32() -> Result<Arc<Self>> {
+    pub async fn new_stm32<W>(_wtb: &W) -> Result<Arc<Self>> {
         let mut demo_magic = block_on(DEMO_MAGIC_STM32.lock());
 
         // Only ever set up a single demo_mode "IioThread" per ADC
@@ -195,7 +195,7 @@ impl IioThread {
         Ok(this)
     }
 
-    pub async fn new_powerboard() -> Result<Arc<Self>> {
+    pub async fn new_powerboard<W>(_wtb: &W) -> Result<Arc<Self>> {
         let mut demo_magic = block_on(DEMO_MAGIC_POWERBOARD.lock());
 
         // Only ever set up a single demo_mode "IioThread" per ADC

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -362,7 +362,9 @@ impl IioThread {
                 Err(e) => {
                     // Can not fail in practice as the queue is known to be empty
                     // at this point.
-                    thread_res_tx.try_send(Err(e)).unwrap();
+                    thread_res_tx
+                        .try_send(Err(e))
+                        .expect("Failed to signal ADC setup error due to full queue");
                     return Ok(());
                 }
             };
@@ -385,7 +387,8 @@ impl IioThread {
                     if let Some((_, tx)) = signal_ready.take() {
                         // Can not fail in practice as the queue is only .take()n
                         // once and thus known to be empty.
-                        tx.try_send(Err(Error::new(e))).unwrap();
+                        tx.try_send(Err(Error::new(e)))
+                            .expect("Failed to signal ADC setup error due to full queue");
                     }
 
                     break;
@@ -415,7 +418,8 @@ impl IioThread {
                 if let Some((content, tx)) = signal_ready.take() {
                     // Can not fail in practice as the queue is only .take()n
                     // once and thus known to be empty.
-                    tx.try_send(Ok(content)).unwrap();
+                    tx.try_send(Ok(content))
+                        .expect("Failed to signal ADC setup completion due to full queue");
                 }
             }
 

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -107,7 +107,7 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    pub async fn new_stm32() -> Result<Arc<Self>> {
+    pub async fn new_stm32<W>(_wtb: &W) -> Result<Arc<Self>> {
         let mut channels = Vec::new();
 
         for name in CHANNELS_STM32 {
@@ -117,7 +117,7 @@ impl IioThread {
         Ok(Arc::new(Self { channels }))
     }
 
-    pub async fn new_powerboard() -> Result<Arc<Self>> {
+    pub async fn new_powerboard<W>(_wtb: &W) -> Result<Arc<Self>> {
         let mut channels = Vec::new();
 
         for name in CHANNELS_PWR {

--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -62,7 +62,7 @@ impl Backlight {
             }
 
             Ok(())
-        });
+        })?;
 
         Ok(Self { brightness })
     }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::sync::Arc;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -115,11 +116,13 @@ impl BrokerBuilder {
     /// Finish building the broker
     ///
     /// This consumes the builder so that no new topics can be registered
-    pub fn build(self, wtb: &mut WatchedTasksBuilder, server: &mut tide::Server<()>) {
+    pub fn build(self, wtb: &mut WatchedTasksBuilder, server: &mut tide::Server<()>) -> Result<()> {
         let topics = Arc::new(self.topics);
 
-        persistence::register(wtb, topics.clone());
+        persistence::register(wtb, topics.clone())?;
         rest::register(server, topics.clone());
         mqtt_conn::register(server, topics);
+
+        Ok(())
     }
 }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -18,6 +18,8 @@
 use async_std::sync::Arc;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::watched_tasks::WatchedTasksBuilder;
+
 mod mqtt_conn;
 mod persistence;
 mod rest;
@@ -113,10 +115,10 @@ impl BrokerBuilder {
     /// Finish building the broker
     ///
     /// This consumes the builder so that no new topics can be registered
-    pub fn build(self, server: &mut tide::Server<()>) {
+    pub fn build(self, wtb: &mut WatchedTasksBuilder, server: &mut tide::Server<()>) {
         let topics = Arc::new(self.topics);
 
-        persistence::register(topics.clone());
+        persistence::register(wtb, topics.clone());
         rest::register(server, topics.clone());
         mqtt_conn::register(server, topics);
     }

--- a/src/broker/persistence.rs
+++ b/src/broker/persistence.rs
@@ -148,7 +148,7 @@ async fn save_on_change(
     Ok(())
 }
 
-pub fn register(wtb: &mut WatchedTasksBuilder, topics: Arc<Vec<Arc<dyn AnyTopic>>>) {
+pub fn register(wtb: &mut WatchedTasksBuilder, topics: Arc<Vec<Arc<dyn AnyTopic>>>) -> Result<()> {
     load(&topics).unwrap();
 
     let (tx, rx) = unbounded();
@@ -157,5 +157,5 @@ pub fn register(wtb: &mut WatchedTasksBuilder, topics: Arc<Vec<Arc<dyn AnyTopic>
         topic.subscribe_as_bytes(tx.clone(), false);
     }
 
-    wtb.spawn_task("persistence-save", save_on_change(topics, rx));
+    wtb.spawn_task("persistence-save", save_on_change(topics, rx))
 }

--- a/src/broker/persistence.rs
+++ b/src/broker/persistence.rs
@@ -22,12 +22,13 @@ use anyhow::{bail, Result};
 use async_std::channel::{unbounded, Receiver};
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_writer_pretty, Map, Value};
 
 use super::{AnyTopic, TopicName};
+
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(feature = "demo_mode")]
 const PERSISTENCE_PATH: &str = "demo_files/srv/tacd/state.json";
@@ -147,7 +148,7 @@ async fn save_on_change(
     Ok(())
 }
 
-pub fn register(topics: Arc<Vec<Arc<dyn AnyTopic>>>) {
+pub fn register(wtb: &mut WatchedTasksBuilder, topics: Arc<Vec<Arc<dyn AnyTopic>>>) {
     load(&topics).unwrap();
 
     let (tx, rx) = unbounded();
@@ -156,5 +157,5 @@ pub fn register(topics: Arc<Vec<Arc<dyn AnyTopic>>>) {
         topic.subscribe_as_bytes(tx.clone(), false);
     }
 
-    spawn(async move { save_on_change(topics, rx).await.unwrap() });
+    wtb.spawn_task("persistence-save", save_on_change(topics, rx));
 }

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -19,6 +19,7 @@ use async_std::sync::Arc;
 
 use crate::broker::{BrokerBuilder, Topic};
 use crate::led::BlinkPattern;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(feature = "demo_mode")]
 mod zb {
@@ -78,6 +79,7 @@ pub struct DbusSession {
 impl DbusSession {
     pub async fn new(
         bb: &mut BrokerBuilder,
+        wtb: &mut WatchedTasksBuilder,
         led_dut: Arc<Topic<BlinkPattern>>,
         led_uplink: Arc<Topic<BlinkPattern>>,
     ) -> Self {
@@ -91,10 +93,10 @@ impl DbusSession {
         let conn = Arc::new(tacd.serve(conn_builder).build().await.unwrap());
 
         Self {
-            hostname: Hostname::new(bb, &conn),
-            network: Network::new(bb, &conn, led_dut, led_uplink),
-            rauc: Rauc::new(bb, &conn),
-            systemd: Systemd::new(bb, &conn).await,
+            hostname: Hostname::new(bb, wtb, &conn),
+            network: Network::new(bb, wtb, &conn, led_dut, led_uplink),
+            rauc: Rauc::new(bb, wtb, &conn),
+            systemd: Systemd::new(bb, wtb, &conn).await,
         }
     }
 }

--- a/src/dbus/hostname.rs
+++ b/src/dbus/hostname.rs
@@ -15,13 +15,14 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
+use async_std::sync::Arc;
+
 #[cfg(not(feature = "demo_mode"))]
 use async_std::stream::StreamExt;
 
 #[cfg(not(feature = "demo_mode"))]
 use zbus::Connection;
-
-use async_std::sync::Arc;
 
 use crate::broker::{BrokerBuilder, Topic};
 use crate::watched_tasks::WatchedTasksBuilder;
@@ -34,10 +35,14 @@ pub struct Hostname {
 
 impl Hostname {
     #[cfg(feature = "demo_mode")]
-    pub fn new<C>(bb: &mut BrokerBuilder, _wtb: &mut WatchedTasksBuilder, _conn: C) -> Self {
-        Self {
+    pub fn new<C>(
+        bb: &mut BrokerBuilder,
+        _wtb: &mut WatchedTasksBuilder,
+        _conn: C,
+    ) -> Result<Self> {
+        Ok(Self {
             hostname: bb.topic_ro("/v1/tac/network/hostname", Some("lxatac".into())),
-        }
+        })
     }
 
     #[cfg(not(feature = "demo_mode"))]
@@ -45,7 +50,7 @@ impl Hostname {
         bb: &mut BrokerBuilder,
         wtb: &mut WatchedTasksBuilder,
         conn: &Arc<Connection>,
-    ) -> Self {
+    ) -> Result<Self> {
         let hostname = bb.topic_ro("/v1/tac/network/hostname", None);
 
         let conn = conn.clone();
@@ -67,8 +72,8 @@ impl Hostname {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self { hostname }
+        Ok(Self { hostname })
     }
 }

--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -318,7 +318,7 @@ impl Rauc {
         bb: &mut BrokerBuilder,
         wtb: &mut WatchedTasksBuilder,
         _conn: &Arc<Connection>,
-    ) -> Self {
+    ) -> Result<Self> {
         let inst = Self::setup_topics(bb);
 
         inst.operation.set("idle".to_string());
@@ -336,9 +336,9 @@ impl Rauc {
                 inst.channels.clone(),
                 inst.slot_status.clone(),
             ),
-        );
+        )?;
 
-        inst
+        Ok(inst)
     }
 
     #[cfg(not(feature = "demo_mode"))]
@@ -346,7 +346,7 @@ impl Rauc {
         bb: &mut BrokerBuilder,
         wtb: &mut WatchedTasksBuilder,
         conn: &Arc<Connection>,
-    ) -> Self {
+    ) -> Result<Self> {
         let inst = Self::setup_topics(bb);
 
         let conn_task = conn.clone();
@@ -455,7 +455,7 @@ impl Rauc {
                     break Ok(());
                 }
             }
-        });
+        })?;
 
         let conn_task = conn.clone();
         let progress = inst.progress.clone();
@@ -477,7 +477,7 @@ impl Rauc {
             }
 
             Ok(())
-        });
+        })?;
 
         let conn_task = conn.clone();
         let last_error = inst.last_error.clone();
@@ -499,7 +499,7 @@ impl Rauc {
             }
 
             Ok(())
-        });
+        })?;
 
         let conn_task = conn.clone();
         let (mut install_stream, _) = inst.install.clone().subscribe_unbounded();
@@ -519,7 +519,7 @@ impl Rauc {
             }
 
             Ok(())
-        });
+        })?;
 
         // Reload the channel list on request
         let (reload_stream, _) = inst.reload.clone().subscribe_unbounded();
@@ -532,9 +532,9 @@ impl Rauc {
                 inst.channels.clone(),
                 inst.slot_status.clone(),
             ),
-        );
+        )?;
 
-        inst
+        Ok(inst)
     }
 }
 

--- a/src/dbus/systemd.rs
+++ b/src/dbus/systemd.rs
@@ -17,8 +17,6 @@
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
-use futures::join;
 use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "demo_mode"))]
@@ -29,6 +27,7 @@ pub use log::warn;
 
 use super::{Connection, Result};
 use crate::broker::{BrokerBuilder, Topic};
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(not(feature = "demo_mode"))]
 mod manager;
@@ -96,12 +95,22 @@ impl Service {
     }
 
     #[cfg(feature = "demo_mode")]
-    async fn connect(&self, _conn: Arc<Connection>, _unit_name: &'static str) {
+    async fn connect(
+        &self,
+        _wtb: &mut WatchedTasksBuilder,
+        _conn: Arc<Connection>,
+        _unit_name: &str,
+    ) {
         self.status.set(ServiceStatus::get().await.unwrap());
     }
 
     #[cfg(not(feature = "demo_mode"))]
-    async fn connect(&self, conn: Arc<Connection>, unit_name: &'static str) {
+    async fn connect(
+        &self,
+        wtb: &mut WatchedTasksBuilder,
+        conn: Arc<Connection>,
+        unit_name: &'static str,
+    ) {
         let unit_path = {
             let manager = manager::ManagerProxy::new(&conn).await.unwrap();
             manager.get_unit(unit_name).await.unwrap()
@@ -117,7 +126,7 @@ impl Service {
         let unit_task = unit.clone();
         let status_topic = self.status.clone();
 
-        spawn(async move {
+        wtb.spawn_task(format!("systemd-{unit_name}-state"), async move {
             let mut active_state_stream =
                 unit_task.receive_active_state_changed().await.map(|_| ());
             let mut sub_state_stream = unit_task.receive_sub_state_changed().await.map(|_| ());
@@ -145,7 +154,7 @@ impl Service {
 
         let (mut action_reqs, _) = self.action.clone().subscribe_unbounded();
 
-        spawn(async move {
+        wtb.spawn_task(format!("systemd-{unit_name}-actions"), async move {
             while let Some(action) = action_reqs.next().await {
                 let res = match action {
                     ServiceAction::Start => unit.start("replace").await,
@@ -160,29 +169,41 @@ impl Service {
                     );
                 }
             }
+
+            Ok(())
         });
     }
 }
 
 impl Systemd {
     #[cfg(feature = "demo_mode")]
-    pub fn handle_reboot(reboot: Arc<Topic<bool>>, _conn: Arc<Connection>) {
+    pub fn handle_reboot(
+        wtb: &mut WatchedTasksBuilder,
+        reboot: Arc<Topic<bool>>,
+        _conn: Arc<Connection>,
+    ) {
         let (mut reboot_reqs, _) = reboot.subscribe_unbounded();
 
-        spawn(async move {
+        wtb.spawn_task("systemd-reboot", async move {
             while let Some(req) = reboot_reqs.next().await {
                 if req {
                     println!("Asked to reboot but don't feel like it");
                 }
             }
+
+            Ok(())
         });
     }
 
     #[cfg(not(feature = "demo_mode"))]
-    pub fn handle_reboot(reboot: Arc<Topic<bool>>, conn: Arc<Connection>) {
+    pub fn handle_reboot(
+        wtb: &mut WatchedTasksBuilder,
+        reboot: Arc<Topic<bool>>,
+        conn: Arc<Connection>,
+    ) {
         let (mut reboot_reqs, _) = reboot.subscribe_unbounded();
 
-        spawn(async move {
+        wtb.spawn_task("systemd-reboot", async move {
             let manager = manager::ManagerProxy::new(&conn).await.unwrap();
 
             while let Some(req) = reboot_reqs.next().await {
@@ -192,23 +213,31 @@ impl Systemd {
                     }
                 }
             }
+
+            Ok(())
         });
     }
 
-    pub async fn new(bb: &mut BrokerBuilder, conn: &Arc<Connection>) -> Self {
+    pub async fn new(
+        bb: &mut BrokerBuilder,
+        wtb: &mut WatchedTasksBuilder,
+        conn: &Arc<Connection>,
+    ) -> Self {
         let reboot = bb.topic_rw("/v1/tac/reboot", Some(false));
 
-        Self::handle_reboot(reboot.clone(), conn.clone());
+        Self::handle_reboot(wtb, reboot.clone(), conn.clone());
 
         let networkmanager = Service::new(bb, "network-manager");
         let labgrid = Service::new(bb, "labgrid-exporter");
         let iobus = Service::new(bb, "lxa-iobus");
 
-        join!(
-            networkmanager.connect(conn.clone(), "NetworkManager.service"),
-            labgrid.connect(conn.clone(), "labgrid-exporter.service"),
-            iobus.connect(conn.clone(), "lxa-iobus.service"),
-        );
+        networkmanager
+            .connect(wtb, conn.clone(), "NetworkManager.service")
+            .await;
+        labgrid
+            .connect(wtb, conn.clone(), "labgrid-exporter.service")
+            .await;
+        iobus.connect(wtb, conn.clone(), "lxa-iobus.service").await;
 
         Self {
             reboot,

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -17,10 +17,10 @@
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 
 use crate::broker::{BrokerBuilder, Topic};
 use crate::led::BlinkPattern;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[allow(clippy::items_after_test_module)]
 #[cfg(test)]
@@ -54,6 +54,7 @@ pub struct DigitalIo {
 /// writing to it. (e.g. whatever it is set to _is_ the line status).
 fn handle_line_wo(
     bb: &mut BrokerBuilder,
+    wtb: &mut WatchedTasksBuilder,
     path: &str,
     line_name: &str,
     initial: bool,
@@ -68,7 +69,7 @@ fn handle_line_wo(
 
     let (mut src, _) = topic.clone().subscribe_unbounded();
 
-    spawn(async move {
+    wtb.spawn_task(format!("digital-io-{line_name}-set"), async move {
         while let Some(ev) = src.next().await {
             dst.set_value((ev ^ inverted) as _).unwrap();
 
@@ -77,6 +78,8 @@ fn handle_line_wo(
                 led.set(pattern);
             }
         }
+
+        Ok(())
     });
 
     topic
@@ -85,11 +88,13 @@ fn handle_line_wo(
 impl DigitalIo {
     pub fn new(
         bb: &mut BrokerBuilder,
+        wtb: &mut WatchedTasksBuilder,
         led_0: Arc<Topic<BlinkPattern>>,
         led_1: Arc<Topic<BlinkPattern>>,
     ) -> Self {
         let out_0 = handle_line_wo(
             bb,
+            wtb,
             "/v1/output/out_0/asserted",
             "OUT_0",
             false,
@@ -99,6 +104,7 @@ impl DigitalIo {
 
         let out_1 = handle_line_wo(
             bb,
+            wtb,
             "/v1/output/out_1/asserted",
             "OUT_1",
             false,
@@ -106,8 +112,24 @@ impl DigitalIo {
             Some(led_1),
         );
 
-        let uart_rx_en = handle_line_wo(bb, "/v1/uart/rx/enabled", "UART_RX_EN", true, true, None);
-        let uart_tx_en = handle_line_wo(bb, "/v1/uart/tx/enabled", "UART_TX_EN", true, true, None);
+        let uart_rx_en = handle_line_wo(
+            bb,
+            wtb,
+            "/v1/uart/rx/enabled",
+            "UART_RX_EN",
+            true,
+            true,
+            None,
+        );
+        let uart_tx_en = handle_line_wo(
+            bb,
+            wtb,
+            "/v1/uart/tx/enabled",
+            "UART_TX_EN",
+            true,
+            true,
+            None,
+        );
 
         Self {
             out_0,

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 
@@ -60,7 +61,7 @@ fn handle_line_wo(
     initial: bool,
     inverted: bool,
     led_topic: Option<Arc<Topic<BlinkPattern>>>,
-) -> Arc<Topic<bool>> {
+) -> Result<Arc<Topic<bool>>> {
     let topic = bb.topic_rw(path, Some(initial));
     let line = find_line(line_name).unwrap();
     let dst = line
@@ -80,9 +81,9 @@ fn handle_line_wo(
         }
 
         Ok(())
-    });
+    })?;
 
-    topic
+    Ok(topic)
 }
 
 impl DigitalIo {
@@ -91,7 +92,7 @@ impl DigitalIo {
         wtb: &mut WatchedTasksBuilder,
         led_0: Arc<Topic<BlinkPattern>>,
         led_1: Arc<Topic<BlinkPattern>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let out_0 = handle_line_wo(
             bb,
             wtb,
@@ -100,7 +101,7 @@ impl DigitalIo {
             false,
             false,
             Some(led_0),
-        );
+        )?;
 
         let out_1 = handle_line_wo(
             bb,
@@ -110,7 +111,7 @@ impl DigitalIo {
             false,
             false,
             Some(led_1),
-        );
+        )?;
 
         let uart_rx_en = handle_line_wo(
             bb,
@@ -120,7 +121,8 @@ impl DigitalIo {
             true,
             true,
             None,
-        );
+        )?;
+
         let uart_tx_en = handle_line_wo(
             bb,
             wtb,
@@ -129,13 +131,13 @@ impl DigitalIo {
             true,
             true,
             None,
-        );
+        )?;
 
-        Self {
+        Ok(Self {
             out_0,
             out_1,
             uart_rx_en,
             uart_tx_en,
-        }
+        })
     }
 }

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -32,8 +32,8 @@ impl LineHandle {
         // It is just a hack to let adc/iio/demo_mode.rs
         // communicate with this function so that toggling an output
         // has an effect on the measured values.
-        let iio_thread_stm32 = block_on(IioThread::new_stm32()).unwrap();
-        let iio_thread_pwr = block_on(IioThread::new_powerboard()).unwrap();
+        let iio_thread_stm32 = block_on(IioThread::new_stm32(&())).unwrap();
+        let iio_thread_pwr = block_on(IioThread::new_powerboard(&())).unwrap();
 
         match self.name.as_str() {
             "OUT_0" => iio_thread_stm32

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -320,9 +320,8 @@ impl DutPwrThread {
 
         // Spawn a high priority thread that handles the power status
         // in a realtimey fashion.
-        thread::Builder::new()
-            .name("tacd power".into())
-            .spawn(move || {
+        wtb.spawn_thread("power-thread", move || {
+            {
                 let mut last_ts: Option<Instant> = None;
 
                 // There may be transients in the measured voltage/current, e.g. due to EMI or
@@ -482,7 +481,10 @@ impl DutPwrThread {
 
                 // Make sure to enter fail safe mode before leaving the thread
                 turn_off_with_reason(OutputState::Off, &pwr_line, &discharge_line, &state);
-            })?;
+            };
+
+            Ok(())
+        })?;
 
         let (tick, request, state) = thread_res_rx.next().await.unwrap()?;
 

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -18,6 +18,7 @@
 use std::fs::write;
 use std::net::TcpListener;
 
+use anyhow::Result;
 use tide::{Body, Response, Server};
 
 use crate::watched_tasks::WatchedTasksBuilder;
@@ -128,10 +129,10 @@ impl HttpServer {
             });
     }
 
-    pub fn serve(self, wtb: &mut WatchedTasksBuilder) {
+    pub fn serve(self, wtb: &mut WatchedTasksBuilder) -> Result<()> {
         wtb.spawn_task("http-server", async move {
             self.server.listen(self.listeners).await?;
             Ok(())
-        });
+        })
     }
 }

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -20,6 +20,8 @@ use std::net::TcpListener;
 
 use tide::{Body, Response, Server};
 
+use crate::watched_tasks::WatchedTasksBuilder;
+
 mod serve_dir;
 use serve_dir::serve_dir;
 
@@ -126,7 +128,10 @@ impl HttpServer {
             });
     }
 
-    pub async fn serve(self) -> Result<(), std::io::Error> {
-        self.server.listen(self.listeners).await
+    pub fn serve(self, wtb: &mut WatchedTasksBuilder) {
+        wtb.spawn_task("http-server", async move {
+            self.server.listen(self.listeners).await?;
+            Ok(())
+        });
     }
 }

--- a/src/iobus.rs
+++ b/src/iobus.rs
@@ -17,6 +17,7 @@
 
 use std::time::Duration;
 
+use anyhow::Result;
 use async_std::sync::Arc;
 use async_std::task::sleep;
 
@@ -114,7 +115,7 @@ impl IoBus {
         iobus_pwr_en: Arc<Topic<bool>>,
         iobus_curr: CalibratedChannel,
         iobus_volt: CalibratedChannel,
-    ) -> Self {
+    ) -> Result<Self> {
         let supply_fault = bb.topic_ro("/v1/iobus/feedback/fault", None);
         let server_info = bb.topic_ro("/v1/iobus/server/info", None);
         let nodes = bb.topic_ro("/v1/iobus/server/nodes", None);
@@ -153,12 +154,12 @@ impl IoBus {
 
                 sleep(Duration::from_secs(1)).await;
             }
-        });
+        })?;
 
-        Self {
+        Ok(Self {
             supply_fault,
             server_info,
             nodes,
-        }
+        })
     }
 }

--- a/src/led.rs
+++ b/src/led.rs
@@ -19,10 +19,10 @@ use std::io::ErrorKind;
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use log::{error, info, warn};
 
 use crate::broker::{BrokerBuilder, Topic};
+use crate::watched_tasks::WatchedTasksBuilder;
 
 mod demo_mode;
 mod extras;
@@ -67,6 +67,7 @@ fn get_led_checked(hardware_name: &'static str) -> Option<Leds> {
 
 fn handle_pattern(
     bb: &mut BrokerBuilder,
+    wtb: &mut WatchedTasksBuilder,
     hardware_name: &'static str,
     topic_name: &'static str,
 ) -> Arc<Topic<BlinkPattern>> {
@@ -75,12 +76,14 @@ fn handle_pattern(
     if let Some(led) = get_led_checked(hardware_name) {
         let (mut rx, _) = topic.clone().subscribe_unbounded();
 
-        spawn(async move {
+        wtb.spawn_task("led-pattern-update", async move {
             while let Some(pattern) = rx.next().await {
                 if let Err(e) = led.set_pattern(pattern) {
                     warn!("Failed to set LED pattern: {}", e);
                 }
             }
+
+            Ok(())
         });
     }
 
@@ -89,6 +92,7 @@ fn handle_pattern(
 
 fn handle_color(
     bb: &mut BrokerBuilder,
+    wtb: &mut WatchedTasksBuilder,
     hardware_name: &'static str,
     topic_name: &'static str,
 ) -> Arc<Topic<(f32, f32, f32)>> {
@@ -97,9 +101,9 @@ fn handle_color(
     if let Some(led) = get_led_checked(hardware_name) {
         let (mut rx, _) = topic.clone().subscribe_unbounded();
 
-        spawn(async move {
+        wtb.spawn_task("led-color-update", async move {
             while let Some((r, g, b)) = rx.next().await {
-                let max = led.max_brightness().unwrap();
+                let max = led.max_brightness()?;
 
                 // I've encountered LEDs staying off when set to the max value,
                 // but setting them to (max - 1) turned them on.
@@ -109,6 +113,8 @@ fn handle_color(
                     warn!("Failed to set LED color: {}", e);
                 }
             }
+
+            Ok(())
         });
     }
 
@@ -116,15 +122,15 @@ fn handle_color(
 }
 
 impl Led {
-    pub fn new(bb: &mut BrokerBuilder) -> Self {
+    pub fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Self {
         Self {
-            out_0: handle_pattern(bb, "tac:green:out0", "out_0"),
-            out_1: handle_pattern(bb, "tac:green:out1", "out_1"),
-            dut_pwr: handle_pattern(bb, "tac:green:dutpwr", "dut_pwr"),
-            eth_dut: handle_pattern(bb, "tac:green:statusdut", "eth_dut"),
-            eth_lab: handle_pattern(bb, "tac:green:statuslab", "eth_lab"),
-            status: handle_pattern(bb, "rgb:status", "status"),
-            status_color: handle_color(bb, "rgb:status", "status"),
+            out_0: handle_pattern(bb, wtb, "tac:green:out0", "out_0"),
+            out_1: handle_pattern(bb, wtb, "tac:green:out1", "out_1"),
+            dut_pwr: handle_pattern(bb, wtb, "tac:green:dutpwr", "dut_pwr"),
+            eth_dut: handle_pattern(bb, wtb, "tac:green:statusdut", "eth_dut"),
+            eth_lab: handle_pattern(bb, wtb, "tac:green:statuslab", "eth_lab"),
+            status: handle_pattern(bb, wtb, "rgb:status", "status"),
+            status_color: handle_color(bb, wtb, "rgb:status", "status"),
         }
     }
 }

--- a/src/led.rs
+++ b/src/led.rs
@@ -17,6 +17,7 @@
 
 use std::io::ErrorKind;
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use log::{error, info, warn};
@@ -70,7 +71,7 @@ fn handle_pattern(
     wtb: &mut WatchedTasksBuilder,
     hardware_name: &'static str,
     topic_name: &'static str,
-) -> Arc<Topic<BlinkPattern>> {
+) -> Result<Arc<Topic<BlinkPattern>>> {
     let topic = bb.topic_ro(&format!("/v1/tac/led/{topic_name}/pattern"), None);
 
     if let Some(led) = get_led_checked(hardware_name) {
@@ -84,10 +85,10 @@ fn handle_pattern(
             }
 
             Ok(())
-        });
+        })?;
     }
 
-    topic
+    Ok(topic)
 }
 
 fn handle_color(
@@ -95,7 +96,7 @@ fn handle_color(
     wtb: &mut WatchedTasksBuilder,
     hardware_name: &'static str,
     topic_name: &'static str,
-) -> Arc<Topic<(f32, f32, f32)>> {
+) -> Result<Arc<Topic<(f32, f32, f32)>>> {
     let topic = bb.topic_ro(&format!("/v1/tac/led/{topic_name}/color"), None);
 
     if let Some(led) = get_led_checked(hardware_name) {
@@ -115,22 +116,22 @@ fn handle_color(
             }
 
             Ok(())
-        });
+        })?;
     }
 
-    topic
+    Ok(topic)
 }
 
 impl Led {
-    pub fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Self {
-        Self {
-            out_0: handle_pattern(bb, wtb, "tac:green:out0", "out_0"),
-            out_1: handle_pattern(bb, wtb, "tac:green:out1", "out_1"),
-            dut_pwr: handle_pattern(bb, wtb, "tac:green:dutpwr", "dut_pwr"),
-            eth_dut: handle_pattern(bb, wtb, "tac:green:statusdut", "eth_dut"),
-            eth_lab: handle_pattern(bb, wtb, "tac:green:statuslab", "eth_lab"),
-            status: handle_pattern(bb, wtb, "rgb:status", "status"),
-            status_color: handle_color(bb, wtb, "rgb:status", "status"),
-        }
+    pub fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Result<Self> {
+        Ok(Self {
+            out_0: handle_pattern(bb, wtb, "tac:green:out0", "out_0")?,
+            out_1: handle_pattern(bb, wtb, "tac:green:out1", "out_1")?,
+            dut_pwr: handle_pattern(bb, wtb, "tac:green:dutpwr", "dut_pwr")?,
+            eth_dut: handle_pattern(bb, wtb, "tac:green:statusdut", "eth_dut")?,
+            eth_lab: handle_pattern(bb, wtb, "tac:green:statuslab", "eth_lab")?,
+            status: handle_pattern(bb, wtb, "rgb:status", "status")?,
+            status_color: handle_color(bb, wtb, "rgb:status", "status")?,
+        })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ async fn init() -> Result<(Ui, HttpServer, WatchedTasksBuilder)> {
     .await?;
     let dig_io = DigitalIo::new(&mut bb, &mut wtb, led.out_0.clone(), led.out_1.clone());
     let regulators = Regulators::new(&mut bb, &mut wtb);
-    let temperatures = Temperatures::new(&mut bb);
+    let temperatures = Temperatures::new(&mut bb, &mut wtb)?;
     let usb_hub = UsbHub::new(
         &mut bb,
         &mut wtb,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@
 
 use anyhow::Result;
 use async_std::future::pending;
-use futures::{select, FutureExt};
 use log::{error, info};
 
 mod adc;
@@ -38,6 +37,7 @@ mod temperatures;
 mod ui;
 mod usb_hub;
 mod watchdog;
+mod watched_tasks;
 
 use adc::Adc;
 use backlight::Backlight;
@@ -55,29 +55,37 @@ use temperatures::Temperatures;
 use ui::{message, setup_display, Display, Ui, UiResources};
 use usb_hub::UsbHub;
 use watchdog::Watchdog;
+use watched_tasks::WatchedTasksBuilder;
 
-async fn init() -> Result<(Ui, HttpServer, Option<Watchdog>)> {
+async fn init() -> Result<(Ui, HttpServer, WatchedTasksBuilder)> {
+    // The tacd spawns a couple of async tasks that should run as long as
+    // the tacd runs and if any one fails the tacd should stop.
+    // These tasks are spawned via the watched task builder.
+    let mut wtb = WatchedTasksBuilder::new();
+
     // The BrokerBuilder collects topics that should be exported via the
     // MQTT/REST APIs.
     // The topics are also used to pass around data inside the tacd.
     let mut bb = BrokerBuilder::new();
 
     // Expose hardware on the TAC via the broker framework.
-    let backlight = Backlight::new(&mut bb)?;
-    let led = Led::new(&mut bb);
-    let adc = Adc::new(&mut bb).await?;
+    let backlight = Backlight::new(&mut bb, &mut wtb)?;
+    let led = Led::new(&mut bb, &mut wtb);
+    let adc = Adc::new(&mut bb, &mut wtb).await?;
     let dut_pwr = DutPwrThread::new(
         &mut bb,
+        &mut wtb,
         adc.pwr_volt.clone(),
         adc.pwr_curr.clone(),
         led.dut_pwr.clone(),
     )
     .await?;
-    let dig_io = DigitalIo::new(&mut bb, led.out_0.clone(), led.out_1.clone());
-    let regulators = Regulators::new(&mut bb);
+    let dig_io = DigitalIo::new(&mut bb, &mut wtb, led.out_0.clone(), led.out_1.clone());
+    let regulators = Regulators::new(&mut bb, &mut wtb);
     let temperatures = Temperatures::new(&mut bb);
     let usb_hub = UsbHub::new(
         &mut bb,
+        &mut wtb,
         adc.usb_host_curr.fast.clone(),
         adc.usb_host1_curr.fast.clone(),
         adc.usb_host2_curr.fast.clone(),
@@ -88,12 +96,14 @@ async fn init() -> Result<(Ui, HttpServer, Option<Watchdog>)> {
     // to them via HTTP / DBus APIs.
     let iobus = IoBus::new(
         &mut bb,
+        &mut wtb,
         regulators.iobus_pwr_en.clone(),
         adc.iobus_curr.fast.clone(),
         adc.iobus_volt.fast.clone(),
     );
     let (hostname, network, rauc, systemd) = {
-        let dbus = DbusSession::new(&mut bb, led.eth_dut.clone(), led.eth_lab.clone()).await;
+        let dbus =
+            DbusSession::new(&mut bb, &mut wtb, led.eth_dut.clone(), led.eth_lab.clone()).await;
 
         (dbus.hostname, dbus.network, dbus.rauc, dbus.systemd)
     };
@@ -112,7 +122,7 @@ async fn init() -> Result<(Ui, HttpServer, Option<Watchdog>)> {
     let mut http_server = HttpServer::new();
 
     // Allow editing some aspects of the TAC configuration when in "setup mode".
-    let setup_mode = SetupMode::new(&mut bb, &mut http_server.server);
+    let setup_mode = SetupMode::new(&mut bb, &mut wtb, &mut http_server.server);
 
     // Expose a live log of the TAC's systemd journal so it can be viewed
     // in the web interface.
@@ -140,43 +150,39 @@ async fn init() -> Result<(Ui, HttpServer, Option<Watchdog>)> {
             usb_hub,
         };
 
-        Ui::new(&mut bb, resources)
+        Ui::new(&mut bb, &mut wtb, resources)?
     };
 
     // Consume the BrokerBuilder (no further topics can be added or removed)
     // and expose the topics via HTTP and MQTT-over-websocket.
-    bb.build(&mut http_server.server);
+    bb.build(&mut wtb, &mut http_server.server);
 
-    Ok((ui, http_server, watchdog))
+    // If a watchdog was requested by systemd we can now start feeding it
+    if let Some(watchdog) = watchdog {
+        watchdog.keep_fed(&mut wtb)?;
+    }
+
+    Ok((ui, http_server, wtb))
 }
 
 async fn run(
     ui: Ui,
     mut http_server: HttpServer,
-    watchdog: Option<Watchdog>,
     display: Display,
+    mut wtb: WatchedTasksBuilder,
 ) -> Result<()> {
     // Expose the display as a .png on the web server
     ui::serve_display(&mut http_server.server, display.screenshooter());
 
+    // Start serving files and the API
+    http_server.serve(&mut wtb);
+
+    // Start drawing the UI
+    ui.run(&mut wtb, display);
+
     info!("Setup complete. Handling requests");
 
-    // Run until the user interface, http server or (if selected) the watchdog
-    // exits (with an error).
-    if let Some(watchdog) = watchdog {
-        select! {
-            ui_err = ui.run(display).fuse() => ui_err,
-            wi_err = http_server.serve().fuse() => wi_err,
-            wd_err = watchdog.keep_fed().fuse() => wd_err,
-        }?
-    } else {
-        select! {
-            ui_err = ui.run(display).fuse() => ui_err,
-            wi_err = http_server.serve().fuse() => wi_err,
-        }?
-    }
-
-    Ok(())
+    wtb.watch().await
 }
 
 #[async_std::main]
@@ -187,7 +193,7 @@ async fn main() -> Result<()> {
     let display = setup_display();
 
     match init().await {
-        Ok((ui, http_server, watchdog)) => run(ui, http_server, watchdog, display).await,
+        Ok((ui, http_server, wtb)) => run(ui, http_server, display, wtb).await,
         Err(e) => {
             // Display a detailed error message on stderr (and thus in the journal) ...
             error!("Failed to initialize tacd: {e}");

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -31,7 +31,7 @@ mod reg {
 
     pub fn regulator_set(name: &str, state: bool) -> Result<()> {
         if name == "output_iobus_12v" {
-            let iio_thread = block_on(IioThread::new_stm32()).unwrap();
+            let iio_thread = block_on(IioThread::new_stm32(&())).unwrap();
 
             iio_thread
                 .clone()

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 
@@ -75,7 +76,7 @@ fn handle_regulator(
     path: &str,
     regulator_name: &'static str,
     initial: bool,
-) -> Arc<Topic<bool>> {
+) -> Result<Arc<Topic<bool>>> {
     let topic = bb.topic_rw(path, Some(initial));
     let (mut src, _) = topic.clone().subscribe_unbounded();
 
@@ -85,16 +86,16 @@ fn handle_regulator(
         }
 
         Ok(())
-    });
+    })?;
 
-    topic
+    Ok(topic)
 }
 
 impl Regulators {
-    pub fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Self {
-        Self {
-            iobus_pwr_en: handle_regulator(bb, wtb, "/v1/iobus/powered", "output-iobus-12v", true),
-            uart_pwr_en: handle_regulator(bb, wtb, "/v1/uart/powered", "output-vuart", true),
-        }
+    pub fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Result<Self> {
+        Ok(Self {
+            iobus_pwr_en: handle_regulator(bb, wtb, "/v1/iobus/powered", "output-iobus-12v", true)?,
+            uart_pwr_en: handle_regulator(bb, wtb, "/v1/uart/powered", "output-vuart", true)?,
+        })
     }
 }

--- a/src/setup_mode.rs
+++ b/src/setup_mode.rs
@@ -21,10 +21,10 @@ use std::path::Path;
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use tide::{http::mime, Request, Response, Server};
 
 use crate::broker::{BrokerBuilder, Topic};
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(feature = "demo_mode")]
 const AUTHORIZED_KEYS_PATH: &str = "demo_files/home/root/ssh/authorized_keys";
@@ -106,7 +106,7 @@ impl SetupMode {
         });
     }
 
-    fn handle_leave_requests(&self, bb: &mut BrokerBuilder) {
+    fn handle_leave_requests(&self, bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) {
         // Use the "register a read-only and a write-only topic with the same name
         // to perform validation" trick that is also used with the DUT power endpoint.
         // We must make sure that a client from the web can only ever trigger _leaving_
@@ -116,17 +116,23 @@ impl SetupMode {
             .subscribe_unbounded();
         let setup_mode = self.setup_mode.clone();
 
-        spawn(async move {
+        wtb.spawn_task("setup-mode-leave-request", async move {
             while let Some(lr) = leave_requests.next().await {
                 if !lr {
                     // Only ever set the setup mode to false in here
                     setup_mode.set(false)
                 }
             }
+
+            Ok(())
         });
     }
 
-    pub fn new(bb: &mut BrokerBuilder, server: &mut Server<()>) -> Self {
+    pub fn new(
+        bb: &mut BrokerBuilder,
+        wtb: &mut WatchedTasksBuilder,
+        server: &mut Server<()>,
+    ) -> Self {
         let this = Self {
             setup_mode: bb.topic("/v1/tac/setup_mode", true, false, true, Some(true), 1),
             show_help: bb.topic(
@@ -139,7 +145,7 @@ impl SetupMode {
             ),
         };
 
-        this.handle_leave_requests(bb);
+        this.handle_leave_requests(bb, wtb);
         this.expose_file_conditionally(server, AUTHORIZED_KEYS_PATH, "/v1/tac/ssh/authorized_keys");
 
         this

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -141,9 +141,10 @@ impl Ui {
         let screens = screens::init(wtb, &res, &alerts, &buttons, &reboot_message, &locator);
 
         handle_buttons(
+            wtb,
             "/dev/input/by-path/platform-gpio-keys-event",
             buttons.clone(),
-        );
+        )?;
 
         // Blink the status LED when locator is active
         let led_status_pattern = res.led.status.clone();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -138,7 +138,7 @@ impl Ui {
         alerts.assert(AlertScreen::ScreenSaver);
 
         // Initialize all the screens now so they can be activated later
-        let screens = screens::init(wtb, &res, &alerts, &buttons, &reboot_message, &locator);
+        let screens = screens::init(wtb, &res, &alerts, &buttons, &reboot_message, &locator)?;
 
         handle_buttons(
             wtb,
@@ -173,7 +173,7 @@ impl Ui {
             }
 
             Ok(())
-        });
+        })?;
 
         Ok(Self {
             screen,
@@ -291,11 +291,11 @@ impl Ui {
         Ok(())
     }
 
-    pub fn run(self, wtb: &mut WatchedTasksBuilder, display: Display) {
+    pub fn run(self, wtb: &mut WatchedTasksBuilder, display: Display) -> Result<()> {
         wtb.spawn_task("screen-render-loop", async move {
             self.render_loop(display).await?;
 
             Ok(())
-        });
+        })
     }
 }

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::sync::Arc;
 use async_trait::async_trait;
 use embedded_graphics::{
@@ -191,34 +192,38 @@ pub(super) fn init(
     buttons: &Arc<Topic<ButtonEvent>>,
     reboot_message: &Arc<Topic<Option<String>>>,
     locator: &Arc<Topic<bool>>,
-) -> Vec<Box<dyn ActivatableScreen>> {
-    vec![
+) -> Result<Vec<Box<dyn ActivatableScreen>>> {
+    Ok(vec![
         Box::new(DigOutScreen::new()),
         Box::new(IoBusScreen::new()),
         Box::new(PowerScreen::new()),
         Box::new(SystemScreen::new()),
         Box::new(UartScreen::new()),
         Box::new(UsbScreen::new()),
-        Box::new(HelpScreen::new(wtb, alerts, &res.setup_mode.show_help)),
-        Box::new(IoBusHealthScreen::new(wtb, alerts, &res.iobus.supply_fault)),
+        Box::new(HelpScreen::new(wtb, alerts, &res.setup_mode.show_help)?),
+        Box::new(IoBusHealthScreen::new(
+            wtb,
+            alerts,
+            &res.iobus.supply_fault,
+        )?),
         Box::new(UpdateInstallationScreen::new(
             wtb,
             alerts,
             &res.rauc.operation,
             reboot_message,
             &res.rauc.should_reboot,
-        )),
-        Box::new(UpdateAvailableScreen::new(wtb, alerts, &res.rauc.channels)),
-        Box::new(RebootConfirmScreen::new(wtb, alerts, reboot_message)),
-        Box::new(ScreenSaverScreen::new(wtb, buttons, alerts)),
-        Box::new(SetupScreen::new(wtb, alerts, &res.setup_mode.setup_mode)),
+        )?),
+        Box::new(UpdateAvailableScreen::new(wtb, alerts, &res.rauc.channels)?),
+        Box::new(RebootConfirmScreen::new(wtb, alerts, reboot_message)?),
+        Box::new(ScreenSaverScreen::new(wtb, buttons, alerts)?),
+        Box::new(SetupScreen::new(wtb, alerts, &res.setup_mode.setup_mode)?),
         Box::new(OverTemperatureScreen::new(
             wtb,
             alerts,
             &res.temperatures.warning,
-        )),
-        Box::new(LocatorScreen::new(wtb, alerts, locator)),
-        Box::new(UsbOverloadScreen::new(wtb, alerts, &res.usb_hub.overload)),
-        Box::new(PowerFailScreen::new(wtb, alerts, &res.dut_pwr.state)),
-    ]
+        )?),
+        Box::new(LocatorScreen::new(wtb, alerts, locator)?),
+        Box::new(UsbOverloadScreen::new(wtb, alerts, &res.usb_hub.overload)?),
+        Box::new(PowerFailScreen::new(wtb, alerts, &res.dut_pwr.state)?),
+    ])
 }

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -69,7 +70,7 @@ impl HelpScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         show_help: &Arc<Topic<bool>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut show_help_events, _) = show_help.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -83,9 +84,9 @@ impl HelpScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/iobus_health.rs
+++ b/src/ui/screens/iobus_health.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -45,7 +46,7 @@ impl IoBusHealthScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         supply_fault: &Arc<Topic<bool>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut supply_fault_events, _) = supply_fault.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -59,9 +60,9 @@ impl IoBusHealthScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/locator.rs
+++ b/src/ui/screens/locator.rs
@@ -17,6 +17,7 @@
 
 use std::time::Instant;
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -50,7 +51,7 @@ impl LocatorScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         locator: &Arc<Topic<bool>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut locator_events, _) = locator.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -64,9 +65,9 @@ impl LocatorScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/overtemperature.rs
+++ b/src/ui/screens/overtemperature.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -45,7 +46,7 @@ impl OverTemperatureScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         warning: &Arc<Topic<Warning>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut warning_events, _) = warning.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -58,9 +59,9 @@ impl OverTemperatureScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/power_fail.rs
+++ b/src/ui/screens/power_fail.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -62,7 +63,7 @@ impl PowerFailScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         out_state: &Arc<Topic<OutputState>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut out_state_events, _) = out_state.clone().subscribe_unbounded();
 
         let alerts = alerts.clone();
@@ -82,9 +83,9 @@ impl PowerFailScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -44,7 +45,7 @@ impl RebootConfirmScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         reboot_message: &Arc<Topic<Option<String>>>,
-    ) -> Self {
+    ) -> Result<Self> {
         // Receive questions like Some("Do you want to reboot?") and activate this screen
         let (mut reboot_message_events, _) = reboot_message.clone().subscribe_unbounded();
         let reboot_message = reboot_message.clone();
@@ -60,9 +61,9 @@ impl RebootConfirmScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self { reboot_message }
+        Ok(Self { reboot_message })
     }
 }
 

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -18,6 +18,7 @@
 use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 
+use anyhow::Result;
 use async_std::future::timeout;
 use async_std::prelude::*;
 use async_std::sync::Arc;
@@ -95,7 +96,7 @@ impl ScreenSaverScreen {
         wtb: &mut WatchedTasksBuilder,
         buttons: &Arc<Topic<ButtonEvent>>,
         alerts: &Arc<Topic<AlertList>>,
-    ) -> Self {
+    ) -> Result<Self> {
         // Activate screensaver if no button is pressed for some time
         let (mut buttons_events, _) = buttons.clone().subscribe_unbounded();
         let alerts = alerts.clone();
@@ -115,9 +116,9 @@ impl ScreenSaverScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -21,7 +21,6 @@ use std::time::{Duration, SystemTime};
 use async_std::future::timeout;
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use async_trait::async_trait;
 use embedded_graphics::{
     mono_font::{ascii::FONT_10X20, MonoFont, MonoTextStyle},
@@ -38,6 +37,7 @@ use super::{
     Screen, Ui,
 };
 use crate::broker::Topic;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 const UI_TEXT_FONT: MonoFont = FONT_10X20;
 const SCREEN_TYPE: AlertScreen = AlertScreen::ScreenSaver;
@@ -91,12 +91,16 @@ impl BounceAnimation {
 pub struct ScreenSaverScreen;
 
 impl ScreenSaverScreen {
-    pub fn new(buttons: &Arc<Topic<ButtonEvent>>, alerts: &Arc<Topic<AlertList>>) -> Self {
+    pub fn new(
+        wtb: &mut WatchedTasksBuilder,
+        buttons: &Arc<Topic<ButtonEvent>>,
+        alerts: &Arc<Topic<AlertList>>,
+    ) -> Self {
         // Activate screensaver if no button is pressed for some time
         let (mut buttons_events, _) = buttons.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
-        spawn(async move {
+        wtb.spawn_task("screen-screensaver-activator", async move {
             loop {
                 let ev = timeout(SCREENSAVER_TIMEOUT, buttons_events.next()).await;
                 let activate_screensaver = match ev {
@@ -109,6 +113,8 @@ impl ScreenSaverScreen {
                     alerts.assert(SCREEN_TYPE);
                 }
             }
+
+            Ok(())
         });
 
         Self

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task::spawn;
@@ -53,7 +54,7 @@ impl SetupScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         setup_mode: &Arc<Topic<bool>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut setup_mode_events, _) = setup_mode.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -67,9 +68,9 @@ impl SetupScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/update_available.rs
+++ b/src/ui/screens/update_available.rs
@@ -17,7 +17,6 @@
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use async_trait::async_trait;
 use embedded_graphics::{
     mono_font::MonoTextStyle, pixelcolor::BinaryColor, prelude::*, text::Text,
@@ -31,6 +30,7 @@ use super::{
 };
 use crate::broker::Topic;
 use crate::dbus::rauc::Channel;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 const SCREEN_TYPE: AlertScreen = AlertScreen::UpdateAvailable;
 
@@ -139,13 +139,17 @@ struct Active {
 }
 
 impl UpdateAvailableScreen {
-    pub fn new(alerts: &Arc<Topic<AlertList>>, channels: &Arc<Topic<Vec<Channel>>>) -> Self {
+    pub fn new(
+        wtb: &mut WatchedTasksBuilder,
+        alerts: &Arc<Topic<AlertList>>,
+        channels: &Arc<Topic<Vec<Channel>>>,
+    ) -> Self {
         let (mut channels_events, _) = channels.clone().subscribe_unbounded();
         let alerts = alerts.clone();
         let selection = Topic::anonymous(Some(Selection::new()));
         let selection_task = selection.clone();
 
-        spawn(async move {
+        wtb.spawn_task("screen-update-available-activator", async move {
             while let Some(channels) = channels_events.next().await {
                 selection_task.modify(|sel| sel.unwrap().update_channels(channels));
 
@@ -155,6 +159,8 @@ impl UpdateAvailableScreen {
                     alerts.deassert(SCREEN_TYPE);
                 }
             }
+
+            Ok(())
         });
 
         Self { selection }

--- a/src/ui/screens/update_available.rs
+++ b/src/ui/screens/update_available.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -143,7 +144,7 @@ impl UpdateAvailableScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         channels: &Arc<Topic<Vec<Channel>>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut channels_events, _) = channels.clone().subscribe_unbounded();
         let alerts = alerts.clone();
         let selection = Topic::anonymous(Some(Selection::new()));
@@ -161,9 +162,9 @@ impl UpdateAvailableScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self { selection }
+        Ok(Self { selection })
     }
 }
 

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -51,7 +52,7 @@ impl UpdateInstallationScreen {
         operation: &Arc<Topic<String>>,
         reboot_message: &Arc<Topic<Option<String>>>,
         should_reboot: &Arc<Topic<bool>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut operation_events, _) = operation.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -64,7 +65,7 @@ impl UpdateInstallationScreen {
             }
 
             Ok(())
-        });
+        })?;
 
         let (mut should_reboot_events, _) = should_reboot.clone().subscribe_unbounded();
         let reboot_message = reboot_message.clone();
@@ -77,9 +78,9 @@ impl UpdateInstallationScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -17,7 +17,6 @@
 
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::spawn;
 use async_trait::async_trait;
 use embedded_graphics::prelude::*;
 
@@ -28,6 +27,7 @@ use super::{
 };
 use crate::broker::Topic;
 use crate::dbus::rauc::Progress;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 const SCREEN_TYPE: AlertScreen = AlertScreen::UpdateInstallation;
 const REBOOT_MESSAGE: &str = "There is a newer
@@ -46,6 +46,7 @@ struct Active {
 
 impl UpdateInstallationScreen {
     pub fn new(
+        wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         operation: &Arc<Topic<String>>,
         reboot_message: &Arc<Topic<Option<String>>>,
@@ -54,24 +55,28 @@ impl UpdateInstallationScreen {
         let (mut operation_events, _) = operation.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
-        spawn(async move {
+        wtb.spawn_task("screen-update-activator", async move {
             while let Some(ev) = operation_events.next().await {
                 match ev.as_str() {
                     "installing" => alerts.assert(SCREEN_TYPE),
                     _ => alerts.deassert(SCREEN_TYPE),
                 };
             }
+
+            Ok(())
         });
 
         let (mut should_reboot_events, _) = should_reboot.clone().subscribe_unbounded();
         let reboot_message = reboot_message.clone();
 
-        spawn(async move {
+        wtb.spawn_task("screen-update-should-reboot", async move {
             while let Some(should_reboot) = should_reboot_events.next().await {
                 if should_reboot {
                     reboot_message.set(Some(REBOOT_MESSAGE.to_string()))
                 }
             }
+
+            Ok(())
         });
 
         Self

--- a/src/ui/screens/usb_overload.rs
+++ b/src/ui/screens/usb_overload.rs
@@ -15,6 +15,7 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+use anyhow::Result;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_trait::async_trait;
@@ -49,7 +50,7 @@ impl UsbOverloadScreen {
         wtb: &mut WatchedTasksBuilder,
         alerts: &Arc<Topic<AlertList>>,
         overload: &Arc<Topic<Option<OverloadedPort>>>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (mut overload_events, _) = overload.clone().subscribe_unbounded();
         let alerts = alerts.clone();
 
@@ -63,9 +64,9 @@ impl UsbOverloadScreen {
             }
 
             Ok(())
-        });
+        })?;
 
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -94,7 +94,7 @@ mod rw {
 
         for (path_tail, iio_channel) in DISABLE_CHANNELS {
             if path.ends_with(path_tail) {
-                let iio_thread = block_on(IioThread::new_stm32()).unwrap();
+                let iio_thread = block_on(IioThread::new_stm32(&())).unwrap();
 
                 iio_thread
                     .get_channel(iio_channel)

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -89,7 +89,7 @@ impl Watchdog {
 
                 notify(false, [(STATE_WATCHDOG, "1")].iter())?;
             }
-        });
+        })?;
 
         Ok(())
     }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -15,12 +15,13 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-use std::io::{Error, ErrorKind, Result};
 use std::time::Duration;
 
+use anyhow::{bail, Result};
 use async_std::task::sleep;
 
 use crate::dut_power::TickReader;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(any(test, feature = "demo_mode"))]
 mod sd {
@@ -73,24 +74,23 @@ impl Watchdog {
     /// - dut_pwr thread - otherwise the tick would not be incremented
     /// - adc thread - if the adc values are too old dut_pwr_thread will
     ///   not increment the tick.
-    pub async fn keep_fed(mut self) -> Result<()> {
+    pub fn keep_fed(mut self, wtb: &mut WatchedTasksBuilder) -> Result<()> {
         notify(false, [(STATE_READY, "1")].iter())?;
 
-        loop {
-            sleep(self.interval).await;
+        wtb.spawn_task("watchdog-feeder", async move {
+            loop {
+                sleep(self.interval).await;
 
-            if self.dut_power_tick.is_stale() {
-                eprintln!("Power Thread has stalled. Will trigger watchdog.");
+                if self.dut_power_tick.is_stale() {
+                    notify(false, [(STATE_WATCHDOG, "trigger")].iter())?;
 
-                notify(false, [(STATE_WATCHDOG, "trigger")].iter())?;
+                    bail!("Power Thread stalled for too long");
+                }
 
-                break Err(Error::new(
-                    ErrorKind::TimedOut,
-                    "Power Thread stalled for too long",
-                ));
+                notify(false, [(STATE_WATCHDOG, "1")].iter())?;
             }
+        });
 
-            notify(false, [(STATE_WATCHDOG, "1")].iter())?;
-        }
+        Ok(())
     }
 }

--- a/src/watched_tasks.rs
+++ b/src/watched_tasks.rs
@@ -1,8 +1,10 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+use std::thread;
 
-use anyhow::{Context as AnyhowContext, Result};
+use anyhow::{anyhow, Context as AnyhowContext, Result};
 use async_std::task;
 use log::info;
 
@@ -14,30 +16,139 @@ use log::info;
 // async_std to have a list of tasks to watch at the same time.
 // We want to keep track of the various long running tasks we spawn in the
 // tacd and want to propagate errors from back to main().
-// This is what WatchedTasks does.
+// We also want the same, with a similar API for actual threads instead of
+// async tasks. WatchedTasks does both.
 //
 // There are other solutions that do basically the same, but did not quite
 // fit our needs:
 //
-//   - async_nursery - Works for async_std but does not look that
-//     great code-wise.
-//   - tokio JoinSet - Does roughly the same as WatchedTasks, but
-//     for tokio (which we do not use).
+//   - async_nursery - Works for async_std but does not handle actual threads
+//     and does not look that great code-wise.
+//   - tokio JoinSet - Does roughly the same as WatchedTasks, but also without
+//     native thread support and - more importantly for tokio (which we do
+//     not use).
 
 type TaskResult = Result<()>;
 type TaskHandle = task::JoinHandle<TaskResult>;
 
+struct ThreadHandle {
+    handle: Option<thread::JoinHandle<TaskResult>>,
+    wake_on_exit: Arc<Mutex<Option<Waker>>>,
+}
+
 pub struct WatchedTasksBuilder {
     tasks: Vec<TaskHandle>,
+    threads: Vec<ThreadHandle>,
 }
 
 pub struct WatchedTasks {
     tasks: Vec<TaskHandle>,
+    threads: Vec<ThreadHandle>,
+}
+
+impl ThreadHandle {
+    fn new<F>(name: String, function: F) -> Result<Self>
+    where
+        F: FnOnce() -> TaskResult + Send + 'static,
+    {
+        let wake_on_exit = Arc::new(Mutex::new(None::<Waker>));
+        let wake_on_exit_thread = wake_on_exit.clone();
+
+        // We initially used async_std::task::spawn_blocking() here,
+        // but that does not seem to be intended for long-running threads but instead
+        // to run blocking operations and get the result of them as a Future.
+        // There is a maximum amount of threads that can be spawned via spawn_blocking()
+        // (configurable via an environment variable) and if more tasks are spawned they
+        // will not start exeuting until enough tasks exit (which in our case they won't).
+        // We also do configurations like setting realtime priorities for threads,
+        // which we should not to for threads that are recycled in a thread pool.
+        // Instead spawn a thread the normal way and handle completion-notifications
+        // manually.
+
+        let handle = thread::Builder::new().name(name).spawn(move || {
+            // We could std::panic::catch_unwind() here in the future to handle
+            // panics inside of spawned threads.
+            let res = function();
+
+            // Keep the Mutex locked until exiting the thread to prevent the case
+            // following race condition:
+            //
+            // - Another thread checks if this one ended (which it did not)
+            // - This thread is about to end and checks wake_on_exit
+            // - The other thread sets wake_on_exit
+            let mut wake_on_exit = wake_on_exit_thread
+                .lock()
+                .map_err(|_| anyhow!("Tried to lock a tainted Mutex"))?;
+
+            if let Some(waker) = wake_on_exit.take() {
+                waker.wake();
+            }
+
+            res
+        })?;
+
+        Ok(Self {
+            handle: Some(handle),
+            wake_on_exit,
+        })
+    }
+
+    fn name(&self) -> Option<&str> {
+        self.handle
+            .as_ref()
+            .and_then(|handle| handle.thread().name())
+    }
+}
+
+impl Future for ThreadHandle {
+    type Output = TaskResult;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        {
+            // Lock the Mutex before checking for thread completion to prevent
+            // the thread from completing while we are setting up the waker.
+            let mut wake_on_exit = self
+                .wake_on_exit
+                .lock()
+                .expect("Tried to lock a tainted Mutex");
+
+            let ready = self
+                .handle
+                .as_ref()
+                .map(|handle| handle.is_finished())
+                .unwrap_or(true);
+
+            if !ready {
+                // The thread is not yet ready. Make sure the current task is polled again
+                // if the thread becomes ready.
+                *wake_on_exit = Some(cx.waker().clone());
+
+                return Poll::Pending;
+            }
+        }
+
+        // Get the actual result of the thread via the JoinHandle.
+        // The handle.join() call is technically blocking, but we know that the
+        // task has completed from the notification channel, so it isn't in practice.
+        let res = self
+            .handle
+            .take()
+            .ok_or_else(|| anyhow!("ThreadHandle was already polled to completion"))
+            .and_then(|handle| match handle.join() {
+                Ok(r) => r,
+                Err(_) => Err(anyhow!("Failed to get thread join result")),
+            });
+
+        Poll::Ready(res)
+    }
 }
 
 impl WatchedTasksBuilder {
     pub fn new() -> Self {
-        Self { tasks: Vec::new() }
+        Self {
+            tasks: Vec::new(),
+            threads: Vec::new(),
+        }
     }
 
     /// Spawn an async task that runs until the end of the program
@@ -59,14 +170,39 @@ impl WatchedTasksBuilder {
         self.tasks.push(task);
     }
 
+    /// Spawn a thread that runs until the end of the program
+    ///
+    /// If any of the threads spawned this way returns, the WatchedTasks
+    /// Future will return the Result of said thread.
+    /// The WatchedTasks Future should be .awaited at the end of main() so
+    /// that the program ends if any of the watched threads ends.
+    pub fn spawn_thread<S, F>(&mut self, name: S, function: F) -> Result<()>
+    where
+        S: Into<String>,
+        F: FnOnce() -> TaskResult + Send + 'static,
+    {
+        let thread = ThreadHandle::new(name.into(), function)?;
+
+        self.threads.push(thread);
+
+        Ok(())
+    }
+
     /// Complete the task and thread creation and enter the steady state of the program
     ///
     /// The returned WatchedTasks should be .awaited at the end of `main()` to end the
     /// program if any of the watched threads or tasks ends.
     pub fn watch(self) -> WatchedTasks {
-        info!("Spawned {} tasks", self.tasks.len(),);
+        info!(
+            "Spawned {} tasks and {} threads",
+            self.tasks.len(),
+            self.threads.len()
+        );
 
-        WatchedTasks { tasks: self.tasks }
+        WatchedTasks {
+            tasks: self.tasks,
+            threads: self.threads,
+        }
     }
 }
 
@@ -82,8 +218,20 @@ impl Future for WatchedTasks {
 
                 let res = res.with_context(|| format!("Failed in task {name}"));
 
-                // The first tasks task to finish determines when all
-                // other should finish as well.
+                // The first task to finish determines when all other should finish as well.
+                return Poll::Ready(res);
+            }
+        }
+
+        for thread in self.threads.iter_mut() {
+            let name = thread.name().unwrap_or("<unknown>").to_owned();
+
+            if let Poll::Ready(res) = Pin::new(thread).poll(cx) {
+                info!("Thread {name} has completed");
+
+                let res = res.with_context(|| format!("Failed in thread {name}"));
+
+                // The first thread to finish determines when all other should finish as well.
                 return Poll::Ready(res);
             }
         }
@@ -105,7 +253,11 @@ mod tests {
 
     const TIMEOUT: Duration = Duration::from_millis(100);
 
-    fn setup_tasks() -> (WatchedTasks, Vec<Sender<TaskResult>>) {
+    fn setup_tasks_and_threads() -> (
+        WatchedTasks,
+        Vec<Sender<TaskResult>>,
+        Vec<Sender<TaskResult>>,
+    ) {
         let mut wtb = WatchedTasksBuilder::new();
 
         // Spawn ten tasks that each wait for a message on a channel and
@@ -125,12 +277,30 @@ mod tests {
             })
             .collect();
 
-        (wtb.watch(), senders_tasks)
+        // Spawn ten tasks that each wait for a message on a channel and
+        // complete if they receive it.
+        let senders_threads: Vec<_> = (0..5)
+            .map(|i| {
+                let (tx, rx) = unbounded();
+
+                wtb.spawn_thread(format!("thread-{i}"), move || {
+                    println!("Hi from thread {i}!");
+                    let res = block_on(rx.recv())?;
+                    println!("Bye from thread {i}!");
+                    res
+                })
+                .unwrap();
+
+                tx
+            })
+            .collect();
+
+        (wtb.watch(), senders_tasks, senders_threads)
     }
 
     #[test]
     fn tasks_end_execution() -> Result<()> {
-        let (mut wt, senders_tasks) = setup_tasks();
+        let (mut wt, senders_tasks, _senders_threads) = setup_tasks_and_threads();
 
         // At this point none of tasks have completed yet.
         // Make sure wt reflects that.
@@ -139,6 +309,25 @@ mod tests {
 
         // Make one of the tasks complete.
         senders_tasks[3].try_send(Ok(()))?;
+
+        // Now wt should complete as well.
+        let wt_late_res = block_on(timeout(TIMEOUT, async { (&mut wt).await }));
+        assert!(matches!(wt_late_res, Ok(Ok(()))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn threads_end_execution() -> Result<()> {
+        let (mut wt, _senders_tasks, senders_threads) = setup_tasks_and_threads();
+
+        // At this point none of threads have completed yet.
+        // Make sure wt reflects that.
+        let wt_early_res = block_on(timeout(TIMEOUT, async { (&mut wt).await }));
+        assert!(wt_early_res.is_err());
+
+        // Make one of the threads complete.
+        senders_threads[3].try_send(Ok(()))?;
 
         // Now wt should complete as well.
         let wt_late_res = block_on(timeout(TIMEOUT, async { (&mut wt).await }));

--- a/src/watched_tasks.rs
+++ b/src/watched_tasks.rs
@@ -157,17 +157,16 @@ impl WatchedTasksBuilder {
     /// Future will return the Result of said task.
     /// The WatchedTasks Future should be .awaited at the end of main() so
     /// that the program ends if any of the watched tasks ends.
-    pub fn spawn_task<S, F>(&mut self, name: S, future: F)
+    pub fn spawn_task<S, F>(&mut self, name: S, future: F) -> Result<()>
     where
         S: Into<String>,
         F: Future<Output = TaskResult> + Send + 'static,
     {
-        let task = task::Builder::new()
-            .name(name.into())
-            .spawn(future)
-            .expect("cannot spawn task");
+        let task = task::Builder::new().name(name.into()).spawn(future)?;
 
         self.tasks.push(task);
+
+        Ok(())
     }
 
     /// Spawn a thread that runs until the end of the program
@@ -271,7 +270,8 @@ mod tests {
                     let res = rx.recv().await?;
                     println!("Bye from task {i}!");
                     res
-                });
+                })
+                .unwrap();
 
                 tx
             })

--- a/src/watched_tasks.rs
+++ b/src/watched_tasks.rs
@@ -1,0 +1,149 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use anyhow::{Context as AnyhowContext, Result};
+use async_std::task;
+use log::info;
+
+// This is a wrapper around async_std::task:spawn() that keeps track of the
+// tasks it spawned. This solves the problem of error propagation from tasks
+// for us.
+// When using async_std::task:spawn() you get a handle back that can be used
+// to check if and how the task has completed, but there is no common way in
+// async_std to have a list of tasks to watch at the same time.
+// We want to keep track of the various long running tasks we spawn in the
+// tacd and want to propagate errors from back to main().
+// This is what WatchedTasks does.
+//
+// There are other solutions that do basically the same, but did not quite
+// fit our needs:
+//
+//   - async_nursery - Works for async_std but does not look that
+//     great code-wise.
+//   - tokio JoinSet - Does roughly the same as WatchedTasks, but
+//     for tokio (which we do not use).
+
+type TaskResult = Result<()>;
+type TaskHandle = task::JoinHandle<TaskResult>;
+
+pub struct WatchedTasksBuilder {
+    tasks: Vec<TaskHandle>,
+}
+
+pub struct WatchedTasks {
+    tasks: Vec<TaskHandle>,
+}
+
+impl WatchedTasksBuilder {
+    pub fn new() -> Self {
+        Self { tasks: Vec::new() }
+    }
+
+    /// Spawn an async task that runs until the end of the program
+    ///
+    /// If any of the tasks spawned this way returns, the WatchedTasks
+    /// Future will return the Result of said task.
+    /// The WatchedTasks Future should be .awaited at the end of main() so
+    /// that the program ends if any of the watched tasks ends.
+    pub fn spawn_task<S, F>(&mut self, name: S, future: F)
+    where
+        S: Into<String>,
+        F: Future<Output = TaskResult> + Send + 'static,
+    {
+        let task = task::Builder::new()
+            .name(name.into())
+            .spawn(future)
+            .expect("cannot spawn task");
+
+        self.tasks.push(task);
+    }
+
+    /// Complete the task and thread creation and enter the steady state of the program
+    ///
+    /// The returned WatchedTasks should be .awaited at the end of `main()` to end the
+    /// program if any of the watched threads or tasks ends.
+    pub fn watch(self) -> WatchedTasks {
+        info!("Spawned {} tasks", self.tasks.len(),);
+
+        WatchedTasks { tasks: self.tasks }
+    }
+}
+
+impl Future for WatchedTasks {
+    type Output = TaskResult;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        for task in self.tasks.iter_mut() {
+            let name = task.task().name().unwrap_or("<unknown>").to_owned();
+
+            if let Poll::Ready(res) = Pin::new(task).poll(cx) {
+                info!("Task {name} has completed");
+
+                let res = res.with_context(|| format!("Failed in task {name}"));
+
+                // The first tasks task to finish determines when all
+                // other should finish as well.
+                return Poll::Ready(res);
+            }
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use async_std::channel::{unbounded, Sender};
+    use async_std::future::timeout;
+    use async_std::task::block_on;
+
+    use super::{TaskResult, WatchedTasks, WatchedTasksBuilder};
+
+    const TIMEOUT: Duration = Duration::from_millis(100);
+
+    fn setup_tasks() -> (WatchedTasks, Vec<Sender<TaskResult>>) {
+        let mut wtb = WatchedTasksBuilder::new();
+
+        // Spawn ten tasks that each wait for a message on a channel and
+        // complete if they receive it.
+        let senders_tasks: Vec<_> = (0..5)
+            .map(|i| {
+                let (tx, rx) = unbounded();
+
+                wtb.spawn_task(format!("task-{i}"), async move {
+                    println!("Hi from task {i}!");
+                    let res = rx.recv().await?;
+                    println!("Bye from task {i}!");
+                    res
+                });
+
+                tx
+            })
+            .collect();
+
+        (wtb.watch(), senders_tasks)
+    }
+
+    #[test]
+    fn tasks_end_execution() -> Result<()> {
+        let (mut wt, senders_tasks) = setup_tasks();
+
+        // At this point none of tasks have completed yet.
+        // Make sure wt reflects that.
+        let wt_early_res = block_on(timeout(TIMEOUT, async { (&mut wt).await }));
+        assert!(wt_early_res.is_err());
+
+        // Make one of the tasks complete.
+        senders_tasks[3].try_send(Ok(()))?;
+
+        // Now wt should complete as well.
+        let wt_late_res = block_on(timeout(TIMEOUT, async { (&mut wt).await }));
+        assert!(matches!(wt_late_res, Ok(Ok(()))));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR is based on an idea from [a discussion](https://github.com/linux-automation/tacd/pull/43#pullrequestreview-1650219550) in PR #43, where it was noticed that errors from tasks and threads propagate nowhere.

This PR fixed that by assembling a list of threads and tasks that should __not__ complete before the end of the program and propagating all errors from these threads and tasks to `main()` and beyond.

This touches a lot of places, as we spawn quite a lot of async_std tasks (the `tacd` logs now say "Spawned 58 tasks tasks and 5 threads").

This PR allows us to add better error handling for tasks and threads (we can for example use the `?` operator to propagate errors out and do not have to resort to `.unwrap()` to at least crash the `tacd` from within a task on error). Adding this better error handling is out of scope for this PR, as it is already large enough.