### PR TITLE
ci: tacd: run basic cargo check against different rust versions

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -60,7 +60,6 @@ jobs:
       fail-fast: false # Run against all versions even if one fails
       matrix:
         version:
-          - "1.63" # Yocto langdale
           - "1.68" # Yocto mickledore
           - "1.70" # Yocto nanbield
           - "nightly"

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -55,6 +55,31 @@ jobs:
           args: ${{ matrix.features }}
           name: Clippy Output
 
+  check:
+    strategy:
+      fail-fast: false # Run against all versions even if one fails
+      matrix:
+        version:
+          - "1.63" # Yocto langdale
+          - "1.68" # Yocto mickledore
+          - "1.70" # Yocto nanbield
+          - "nightly"
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt update
+      - run: sudo apt install libsystemd-dev libiio-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.version }}
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
   deny:
     name: cargo deny
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.23.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e9efbe14612da0a19fb983059a0b621e9cf6225d7018ecab4f9988215540dc"
+checksum = "ce01ac37fdc85f10a43c43bc582cbd566720357011578a935761075f898baf58"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
 dependencies = [
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0"
 async-sse = "5.1"
 async-std = { version = "1.12", features = ["attributes"] }
 async-trait = "0.1"
-async-tungstenite = "0.23"
+async-tungstenite = "0.22"
 base64 = "0.21"
 chrono = "0.4"
 embedded-graphics = "0.7"

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ ignore = [
    "RUSTSEC-2021-0059",
    "RUSTSEC-2021-0060",
    "RUSTSEC-2021-0064",
+   "RUSTSEC-2023-0065",
 ]
 
 [bans]

--- a/src/dbus/networkmanager/devices.rs
+++ b/src/dbus/networkmanager/devices.rs
@@ -414,5 +414,4 @@ pub mod ip4 {
     }
 }
 pub use device::DeviceProxy;
-pub use statistics::StatisticsProxy;
 pub use wired::WiredProxy;

--- a/src/dbus/rauc/mod.rs
+++ b/src/dbus/rauc/mod.rs
@@ -66,8 +66,8 @@ mod imports {
 #[cfg(not(feature = "demo_mode"))]
 mod imports {
     pub use anyhow::{anyhow, bail, Result};
-    pub use futures::{select, FutureExt};
-    pub use log::{error, info};
+    pub use futures::FutureExt;
+    pub use log::error;
 
     pub const CHANNELS_DIR: &str = "/usr/share/tacd/update_channels";
 }


### PR DESCRIPTION
We should make sure the tacd at least builds using the rust toolchain used in meta-lxatac.
As we are currently a bit in between chairs when it comes to Yocto versions.
We should thus test for langdale (1.63), mickledore (1.68) and nanbield (1.70).
Also throw in a nightly build for good measure.