### PR TITLE
web: setup: Simplify the setup wizard and other cleanups

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -105,16 +105,19 @@ function Navigation() {
             items: [
               {
                 type: "link",
+                external: true,
                 text: "Files in /srv/www",
                 href: `/srv`,
               },
               {
                 type: "link",
+                external: true,
                 text: "LXA IOBus Server",
                 href: `http://${window.location.hostname}:8080/`,
               },
               {
                 type: "link",
+                external: true,
                 text: "LXA TAC Manual",
                 href: "https://www.linux-automation.com/lxatac-M02/index.html",
               },

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -18,19 +18,14 @@
 import { useState } from "react";
 
 import Box from "@cloudscape-design/components/box";
-import Button from "@cloudscape-design/components/button";
-import Cards from "@cloudscape-design/components/cards";
 import Container from "@cloudscape-design/components/container";
 import Header from "@cloudscape-design/components/header";
-import Form from "@cloudscape-design/components/form";
-import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Wizard from "@cloudscape-design/components/wizard";
 
-import { SlotStatus } from "./TacComponents";
 import { LabgridService, LabgridConfig } from "./SettingsLabgrid";
 import { ConfigEditor } from "./ConfigEditor";
-import { useMqttState, useMqttAction } from "./mqtt";
+import { useMqttState } from "./mqtt";
 
 const SSH_AUTH_KEYS_EXAMPLE =
   "# Paste one (or multiple) of your ssh public keys here.\n" +
@@ -39,389 +34,114 @@ const SSH_AUTH_KEYS_EXAMPLE =
   "# They will look something like this:\n" +
   "# ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBlPtT5dnGcZn0Z6FyD6VGqt3Jx0s+BHhMahxR0KlJ8G tux@igloo\n";
 
-enum WizardChoice {
-  Undecided,
-  Ssh,
-  CustomBundle,
-}
-
-enum LeaveAction {
-  None,
-  HelpScreen,
-  Reboot,
-}
-
-interface WizardProps {
-  setWizard: (w: WizardChoice) => void;
-  setSetupMode: (m: boolean) => void;
-  setLeaveAction: (m: LeaveAction) => void;
-}
-
-function WizardSelector(props: WizardProps) {
-  const [selection, setSelection] = useState<any>();
-  const [canContinue, setCanContinue] = useState(false);
-
-  return (
-    <Container
-      header={
-        <Header
-          variant="h1"
-          description="Choose how you want to continue with the setup of your LXA TAC"
-        >
-          Setup Wizard
-        </Header>
-      }
-    >
-      <SpaceBetween size="xxl">
-        <Box variant="p" fontSize="display-l" textAlign="center">
-          Welcome to your LXA TAC!
-        </Box>
-        <Box variant="p">
-          The following wizard will guide you through the first time setup of
-          your TAC. Begin the setup process by choosing whether to keep using
-          the software that is already installed on your TAC or by installing a
-          pre-configured RAUC bundle you have prepared.
-        </Box>
-        <Form
-          actions={
-            <Button
-              variant="primary"
-              disabled={!canContinue}
-              onClick={(d) => props.setWizard(selection[0].kind)}
-            >
-              Continue
-            </Button>
-          }
-        >
-          <Cards
-            onSelectionChange={({ detail }) => {
-              setCanContinue(true);
-              setSelection(detail.selectedItems);
-            }}
-            selectedItems={selection}
-            cardDefinition={{
-              header: (e) => e.name,
-              sections: [
-                {
-                  id: "benefits",
-                  header: "Benefits:",
-                  content: (e) => e.benefits,
-                },
-                {
-                  id: "drawbacks",
-                  header: "Drawbacks:",
-                  content: (e) => e.drawbacks,
-                },
-              ],
-            }}
-            cardsPerRow={[{ cards: 2 }]}
-            items={[
-              {
-                name: "Setup via SSH keys",
-                kind: WizardChoice.Ssh,
-                benefits: (
-                  <ul>
-                    <li>Get started immediately</li>
-                    <li>Always get the newest software for your LXA TAC</li>
-                    <li>Easier to set up</li>
-                  </ul>
-                ),
-                drawbacks: (
-                  <ul>
-                    <li>Can get tedious in larger fleets</li>
-                  </ul>
-                ),
-              },
-              {
-                name: "Setup via custom RAUC bundle",
-                kind: WizardChoice.CustomBundle,
-                benefits: (
-                  <ul>
-                    <li>
-                      Quickly integrate new LXA TACs into an existing fleet
-                    </li>
-                    <li>Deploy a custom selection of software</li>
-                    <li>Deploy custom config</li>
-                  </ul>
-                ),
-                drawbacks: (
-                  <ul>
-                    <li>
-                      Requires up-front work to configure and build bundles
-                    </li>
-                    <li>
-                      You have to manually re-build bundles to get software
-                      updates
-                    </li>
-                  </ul>
-                ),
-              },
-            ]}
-            selectionType="single"
-            trackBy="name"
-          />
-        </Form>
-      </SpaceBetween>
-    </Container>
-  );
-}
-
-function SshWizard(props: WizardProps) {
-  const [activeStepIndex, setActiveStepIndex] = useState(0);
-
-  return (
-    <Container
-      header={
-        <Header variant="h1" description="Setup via SSH keys">
-          SSH key based Wizard
-        </Header>
-      }
-    >
-      <Wizard
-        i18nStrings={{
-          stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
-          collapsedStepsLabel: (stepNumber, stepsCount: number) =>
-            `Step ${stepNumber} of ${stepsCount}`,
-          skipToButtonLabel: (step, stepNumber) => `Skip to ${step.title}`,
-          navigationAriaLabel: "Steps",
-          cancelButton: "Cancel",
-          previousButton: "Back",
-          nextButton: "Next",
-          submitButton: "Done",
-          optional: "optional",
-        }}
-        onCancel={() => props.setWizard(WizardChoice.Undecided)}
-        onSubmit={() => {
-          props.setLeaveAction(LeaveAction.HelpScreen);
-          props.setSetupMode(false);
-        }}
-        onNavigate={({ detail }) =>
-          setActiveStepIndex(detail.requestedStepIndex)
-        }
-        activeStepIndex={activeStepIndex}
-        allowSkipTo
-        steps={[
-          {
-            title: "Add SSH keys",
-            description:
-              "Deploy SSH keys on your LXA TAC so you can log into it",
-            content: (
-              <Container>
-                <ConfigEditor
-                  path="/v1/tac/ssh/authorized_keys"
-                  language="text"
-                  defaultContent={SSH_AUTH_KEYS_EXAMPLE}
-                />
-              </Container>
-            ),
-          },
-          {
-            title: "Configure Labgrid",
-            description: "Configure your labgrid Exporter",
-            isOptional: true,
-            content: (
-              <Container>
-                <LabgridConfig />
-              </Container>
-            ),
-          },
-          {
-            title: "Test Labgrid",
-            description: "Make sure your labgrid Exporter Service looks healty",
-            isOptional: true,
-            content: (
-              <Container>
-                <LabgridService />
-              </Container>
-            ),
-          },
-          {
-            title: "Complete Setup",
-            description: "Make sure everything is working alright",
-            content: (
-              <Container>
-                <Box>You are about to complete the setup wizard.</Box>
-                <Box>
-                  You will not be able to re-enter the setup wizard to deploy
-                  new SSH keys via the web interface. You can however re-enable
-                  the setup wizard using the buttons and the screen on the
-                  device. If you do not have physical access the TAC you should
-                  make sure that you can log in to the device via the SSH keys
-                  you have deployed before pressing "Done".
-                </Box>
-              </Container>
-            ),
-          },
-        ]}
-      />
-    </Container>
-  );
-}
-
-function CustomBundleWizard(props: WizardProps) {
-  const [activeStepIndex, setActiveStepIndex] = useState(0);
-
-  return (
-    <Container
-      header={
-        <Header variant="h1" description="Setup via custom RAUC bundle">
-          RAUC based Wizard
-        </Header>
-      }
-    >
-      <Wizard
-        i18nStrings={{
-          stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
-          collapsedStepsLabel: (stepNumber, stepsCount: number) =>
-            `Step ${stepNumber} of ${stepsCount}`,
-          skipToButtonLabel: (step, stepNumber) => `Skip to ${step.title}`,
-          navigationAriaLabel: "Steps",
-          cancelButton: "Cancel",
-          previousButton: "Back",
-          nextButton: "Next",
-          submitButton: "Reboot",
-          optional: "optional",
-        }}
-        onCancel={() => props.setWizard(WizardChoice.Undecided)}
-        onSubmit={() => {
-          props.setLeaveAction(LeaveAction.Reboot);
-          props.setSetupMode(false);
-        }}
-        onNavigate={({ detail }) =>
-          setActiveStepIndex(detail.requestedStepIndex)
-        }
-        activeStepIndex={activeStepIndex}
-        allowSkipTo
-        steps={[
-          {
-            title: "Add Signing Key",
-            description:
-              "Add a public key that matches the key your bundles are signed with",
-            content: (
-              <Container>
-                <Box>Sorry, this is not yet implemented</Box>
-              </Container>
-            ),
-          },
-          {
-            title: "Check Slot Status",
-            description: "Make sure everything look correct",
-            isOptional: true,
-            content: <SlotStatus />,
-          },
-          {
-            title: "Complete Setup",
-            description: "Make sure everything look correct",
-            content: (
-              <Container>
-                <Box>You are about to complete the setup wizard.</Box>
-                <Box>Lorem Ipsum Dolor Sit Amet</Box>
-              </Container>
-            ),
-          },
-        ]}
-      />
-    </Container>
-  );
-}
-
-function SetupComplete() {
-  return (
-    <Container
-      header={
-        <Header variant="h1" description="Your LXA TAC is already set up">
-          Setup Complete
-        </Header>
-      }
-    >
-      <Form
-        actions={
-          <Button variant="link" href="/#/">
-            Start Exploring!
-          </Button>
-        }
-      >
-        <SpaceBetween size="m">
-          <Box>
-            It looks like your LXA TAC is fully set up and you are ready to
-            explore its features 🎉!
-          </Box>
-          <Box>
-            You can always go back to the setup mode by going to the system
-            screen on the on-device LCD and selecting the setup mode.
-          </Box>
-        </SpaceBetween>
-      </Form>
-    </Container>
-  );
-}
-
 export default function Setup() {
   const [setupModeSettled, setupMode, setSetupMode] =
     useMqttState<boolean>("/v1/tac/setup_mode");
-  const setReboot = useMqttAction<boolean>("/v1/tac/reboot");
-  const setScreen = useMqttAction<string>("/v1/tac/display/screen");
-  const [wizard, setWizard] = useState(WizardChoice.Undecided);
-  const [leaveAction, setLeaveAction] = useState(LeaveAction.None);
-
-  let content = undefined;
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
 
   if (setupMode === undefined || !setupModeSettled) {
-    content = (
-      <div id="setup_wizard_spinner">
-        <Spinner size="large" />
+    return (
+      <div id="setup_wizard_outer">
+        <div id="setup_wizard_inner">
+          <div id="setup_wizard_spinner">
+            <Spinner size="large" />
+          </div>
+        </div>
       </div>
     );
-  } else if (setupMode) {
-    switch (wizard) {
-      case WizardChoice.Ssh: {
-        content = (
-          <SshWizard
-            setWizard={setWizard}
-            setSetupMode={setSetupMode}
-            setLeaveAction={setLeaveAction}
-          />
-        );
-        break;
-      }
-      case WizardChoice.CustomBundle: {
-        content = (
-          <CustomBundleWizard
-            setWizard={setWizard}
-            setSetupMode={setSetupMode}
-            setLeaveAction={setLeaveAction}
-          />
-        );
-        break;
-      }
-      default: {
-        content = (
-          <WizardSelector
-            setWizard={setWizard}
-            setSetupMode={setSetupMode}
-            setLeaveAction={setLeaveAction}
-          />
-        );
-        break;
-      }
-    }
-  } else {
-    if (leaveAction === LeaveAction.Reboot) {
-      setReboot(true);
-      setLeaveAction(LeaveAction.None);
-    }
+  }
 
-    if (leaveAction === LeaveAction.HelpScreen) {
-      setScreen("Help");
-      setLeaveAction(LeaveAction.None);
-    }
-
-    content = <SetupComplete />;
+  if (!setupMode) {
+    window.location.replace("/#/");
   }
 
   return (
     <div id="setup_wizard_outer">
-      <div id="setup_wizard_inner">{content}</div>
+      <div id="setup_wizard_inner">
+        <Container
+          header={
+            <Header variant="h1" description="Setup via SSH keys">
+              SSH key based Wizard
+            </Header>
+          }
+        >
+          <Wizard
+            i18nStrings={{
+              stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
+              collapsedStepsLabel: (stepNumber, stepsCount: number) =>
+                `Step ${stepNumber} of ${stepsCount}`,
+              skipToButtonLabel: (step, stepNumber) => `Skip to ${step.title}`,
+              navigationAriaLabel: "Steps",
+              cancelButton: "Cancel",
+              previousButton: "Back",
+              nextButton: "Next",
+              submitButton: "Done",
+              optional: "optional",
+            }}
+            onSubmit={() => setSetupMode(false)}
+            onNavigate={({ detail }) =>
+              setActiveStepIndex(detail.requestedStepIndex)
+            }
+            activeStepIndex={activeStepIndex}
+            allowSkipTo
+            steps={[
+              {
+                title: "Add SSH keys",
+                description:
+                  "Deploy SSH keys on your LXA TAC so you can log into it",
+                content: (
+                  <Container>
+                    <ConfigEditor
+                      path="/v1/tac/ssh/authorized_keys"
+                      language="text"
+                      defaultContent={SSH_AUTH_KEYS_EXAMPLE}
+                    />
+                  </Container>
+                ),
+              },
+              {
+                title: "Configure Labgrid",
+                description: "Configure your labgrid Exporter",
+                isOptional: true,
+                content: (
+                  <Container>
+                    <LabgridConfig />
+                  </Container>
+                ),
+              },
+              {
+                title: "Test Labgrid",
+                description:
+                  "Make sure your labgrid Exporter Service looks healty",
+                isOptional: true,
+                content: (
+                  <Container>
+                    <LabgridService />
+                  </Container>
+                ),
+              },
+              {
+                title: "Complete Setup",
+                description: "Make sure everything is working alright",
+                content: (
+                  <Container>
+                    <Box>You are about to complete the setup wizard.</Box>
+                    <Box>
+                      You will not be able to re-enter the setup wizard to
+                      deploy new SSH keys via the web interface. You can however
+                      re-enable the setup wizard using the buttons and the
+                      screen on the device. If you do not have physical access
+                      the TAC you should make sure that you can log in to the
+                      device via the SSH keys you have deployed before pressing
+                      "Done".
+                    </Box>
+                  </Container>
+                ),
+              },
+            ]}
+          />
+        </Container>
+      </div>
     </div>
   );
 }

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -19,7 +19,10 @@ import { useState } from "react";
 
 import Box from "@cloudscape-design/components/box";
 import Container from "@cloudscape-design/components/container";
+import Icon from "@cloudscape-design/components/icon";
 import Header from "@cloudscape-design/components/header";
+import Link from "@cloudscape-design/components/link";
+import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Wizard from "@cloudscape-design/components/wizard";
 
@@ -60,8 +63,8 @@ export default function Setup() {
       <div id="setup_wizard_inner">
         <Container
           header={
-            <Header variant="h1" description="Setup via SSH keys">
-              SSH key based Wizard
+            <Header variant="h1" description="Get started with your TAC">
+              LXA TAC Setup Wizard
             </Header>
           }
         >
@@ -86,16 +89,80 @@ export default function Setup() {
             allowSkipTo
             steps={[
               {
-                title: "Add SSH keys",
-                description:
-                  "Deploy SSH keys on your LXA TAC so you can log into it",
+                title: "Welcome",
+                description: "Welcome to your TAC and its setup mode",
                 content: (
                   <Container>
-                    <ConfigEditor
-                      path="/v1/tac/ssh/authorized_keys"
-                      language="text"
-                      defaultContent={SSH_AUTH_KEYS_EXAMPLE}
-                    />
+                    <Box variant="p">Hey there,</Box>
+                    <Box variant="p">
+                      thank you for buying this TAC. We hope you'll like it!
+                    </Box>
+                    <Box variant="p">
+                      Before you can get started using your TAC we need to set
+                      up a few things so they match your preferences. Some of
+                      these preferences can only be set via the web interface in
+                      this special setup mode, because they affect the security
+                      and inner workings of your TAC. To configure them once the
+                      setup mode is done you either need ssh access to your TAC
+                      or physical access to re-enable the setup mode via the
+                      buttons on the TAC.
+                    </Box>
+                    <Box variant="p">
+                      Ready to get started? Then maybe have a quick look at the{" "}
+                      <Link
+                        external
+                        href="https://www.linux-automation.com/lxatac-M02/index.html"
+                      >
+                        online manual
+                      </Link>{" "}
+                      first and then click "Next" to continue the setup.
+                    </Box>
+                    <br />
+                    <SpaceBetween direction="horizontal" size="s">
+                      <Icon url="/logo.svg" size="large" />
+                      <Box variant="p">
+                        Greetings,
+                        <br />
+                        the Linux Automation GmbH team
+                      </Box>
+                    </SpaceBetween>
+                  </Container>
+                ),
+              },
+              {
+                title: "Add SSH keys",
+                description:
+                  "Deploy SSH keys onto your LXA TAC so you can log into it",
+                content: (
+                  <Container>
+                    <SpaceBetween size="s">
+                      <Box variant="p">
+                        For many actions on the LXA TAC you need access to it
+                        via ssh. Permissions to ssh into the TAC are managed via
+                        a list of ssh public keys, that allow logging in as the
+                        root user.
+                        <br />
+                        Paste a list of ssh public keys into the text box below,
+                        to allow them to access the TAC, and click "Save".
+                        Afterwards you should be able to log into your TAC like
+                        this:
+                        <Box
+                          variant="code"
+                          display="block"
+                          padding="s"
+                          fontSize="body-m"
+                        >
+                          $ ssh root@{window.location.hostname}
+                        </Box>
+                        Make sure to check if logging in works before leaving
+                        the setup mode.
+                      </Box>
+                      <ConfigEditor
+                        path="/v1/tac/ssh/authorized_keys"
+                        language="text"
+                        defaultContent={SSH_AUTH_KEYS_EXAMPLE}
+                      />
+                    </SpaceBetween>
                   </Container>
                 ),
               },
@@ -105,18 +172,45 @@ export default function Setup() {
                 isOptional: true,
                 content: (
                   <Container>
-                    <LabgridConfig />
+                    <SpaceBetween size="s">
+                      <Box variant="p">
+                        The LXA TAC comes with a mostly pre-configured labgrid
+                        exporter, that exports a lot of resources that are built
+                        into the TAC or can be connected to it via USB.
+                        <br />
+                        You may however want to configure the labgrid
+                        coordinator IP address/hostname on the "Environment" tab
+                        or export additional resources in the "User Config" tab.
+                        <br />
+                        Once you have made the required changes click "Save" and
+                        test your configuration by clicking "Next".
+                      </Box>
+                      <LabgridConfig />
+                    </SpaceBetween>
                   </Container>
                 ),
               },
               {
                 title: "Test Labgrid",
                 description:
-                  "Make sure your labgrid Exporter Service looks healty",
+                  "Make sure your labgrid Exporter Service looks healthy",
                 isOptional: true,
                 content: (
                   <Container>
-                    <LabgridService />
+                    <SpaceBetween size="m">
+                      <Box variant="p">
+                        In this step you can check if the labgrid exporter
+                        starts as expected and the correct resources are
+                        exported. Use the "Start", "Stop" and "Restart" buttons
+                        to control the labgrid exporter systemd service and
+                        observe the systemd journal output in the text window
+                        above them.
+                        <br />
+                        Go back to the exporter configuration step to make
+                        changes and click "Next" once you are satisfied.
+                      </Box>
+                      <LabgridService />
+                    </SpaceBetween>
                   </Container>
                 ),
               },
@@ -125,15 +219,24 @@ export default function Setup() {
                 description: "Make sure everything is working alright",
                 content: (
                   <Container>
-                    <Box>You are about to complete the setup wizard.</Box>
-                    <Box>
-                      You will not be able to re-enter the setup wizard to
-                      deploy new SSH keys via the web interface. You can however
-                      re-enable the setup wizard using the buttons and the
-                      screen on the device. If you do not have physical access
-                      the TAC you should make sure that you can log in to the
-                      device via the SSH keys you have deployed before pressing
-                      "Done".
+                    <Box variant="p">
+                      You are about to complete the setup wizard.
+                    </Box>
+                    <Box variant="p">
+                      You will not be able to re-enter the setup wizard via the
+                      web interface. You can however re-enable the setup wizard
+                      using the buttons and the screen on the device. If you do
+                      not have physical access to the TAC you should make sure
+                      that you can log in now using:
+                      <Box
+                        variant="code"
+                        display="block"
+                        padding="s"
+                        fontSize="body-m"
+                      >
+                        $ ssh root@{window.location.hostname}
+                      </Box>
+                      before pressing "Done".
                     </Box>
                   </Container>
                 ),

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -35,7 +35,8 @@ const SSH_AUTH_KEYS_EXAMPLE =
   "# Use 'cat ~/.ssh/id_*.pub' to get a list of your ssh public\n" +
   "# keys or ssh-keygen if you don't have any yet.\n" +
   "# They will look something like this:\n" +
-  "# ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBlPtT5dnGcZn0Z6FyD6VGqt3Jx0s+BHhMahxR0KlJ8G tux@igloo\n";
+  "#\n" +
+  "# ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBlPtT5dnGcZn0Z6FyD6VGqt3Jx0s+BHhMahxR0KlJ8G tux@igloo";
 
 export default function Setup() {
   const [setupModeSettled, setupMode, setSetupMode] =

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -265,6 +265,7 @@ export function UpdateChannels() {
         {
           id: "description",
           header: "Description",
+          maxWidth: "50em",
           cell: (e) => (
             <SpaceBetween size="xs">
               {e.description.split("\n").map((p) => (


### PR DESCRIPTION
Previously the `tacd` presented every new user with a choice between two setup methods:

![Screenshot 2023-11-21 at 07-13-01 LXA TAC (lxatac-00011)](https://github.com/linux-automation/tacd/assets/1273320/355b3702-61f4-4419-b67d-b3244708ff0b)

The "custom bundle" was however not yet implemented and only shows a respective message when selected.
I think the custom bundle method can be integrated into the normal wizard flow once we implement it, so there is no need to keep the selection page.

I've also added a bit more description text to each wizard page. See the screenshots below for reference:

<img src="https://github.com/linux-automation/tacd/assets/1273320/60a463ec-a367-43bf-bea6-f3aa1580132b" width="150px"/>
<img src="https://github.com/linux-automation/tacd/assets/1273320/3eddca21-6978-4af8-b8b2-6cdf0a194929" width="150px"/>
<img src="https://github.com/linux-automation/tacd/assets/1273320/6612f49f-1d20-4cb7-841a-cff5a350bec5" width="150px"/>
<img src="https://github.com/linux-automation/tacd/assets/1273320/e9c1a8e8-3a1c-4fc1-925d-08da31af8984" width="150px"/>
<img src="https://github.com/linux-automation/tacd/assets/1273320/cd74e765-1ef1-4800-8337-0dc9531d626e" width="150px"/>

or try it out yourself:

```bash
$ rm demo_files/srv/tacd/state.json # state file in git that turns setup mode off. Remove it
$ cd web
$ npm install .
$ npm run build
$ cd -
$ cargo run --features=demo_mode --no-default-features
```