### PR TITLE
Ask the user for consent before polling for updates online

### DIFF
--- a/demo_files/srv/tacd/state.json
+++ b/demo_files/srv/tacd/state.json
@@ -2,6 +2,7 @@
   "format_version": 1,
   "persistent_topics": {
     "/v1/tac/display/show_help": false,
-    "/v1/tac/setup_mode": false
+    "/v1/tac/setup_mode": false,
+    "/v1/tac/update/enable_polling": true
   }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -743,6 +743,21 @@ paths:
               schema:
                 type: number
 
+  /v1/tac/update/enable_polling:
+    put:
+      summary: Enable periodic polling for operating system updates
+      tags: [Updating]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: boolean
+      responses:
+        '204':
+          description: Polling for OS updates was enabled/disabled
+        '400':
+          description: The value could not be parsed as boolean
+
   /v1/tac/update/operation:
     get:
       summary: Get the currently running system update operation

--- a/src/broker/topic.rs
+++ b/src/broker/topic.rs
@@ -336,6 +336,19 @@ impl<E: Serialize + DeserializeOwned + Clone + PartialEq> Topic<E> {
 
         self.modify(|prev| if prev != msg { msg } else { None });
     }
+
+    /// Wait until the topic is set to the specified value
+    #[allow(dead_code)]
+    pub async fn wait_for(self: &Arc<Self>, val: E) {
+        let (mut stream, sub) = self.clone().subscribe_unbounded();
+
+        // Unwrap here to keep the interface simple. The stream could only yield
+        // None if the sender side is dropped, which will not happen as we hold
+        // an Arc to self which contains the senders vec.
+        while stream.next().await.unwrap() != val {}
+
+        sub.unsubscribe()
+    }
 }
 
 impl<E: Serialize + DeserializeOwned + Clone + Not + Not<Output = E>> Topic<E> {

--- a/src/broker/topic.rs
+++ b/src/broker/topic.rs
@@ -338,7 +338,6 @@ impl<E: Serialize + DeserializeOwned + Clone + PartialEq> Topic<E> {
     }
 
     /// Wait until the topic is set to the specified value
-    #[allow(dead_code)]
     pub async fn wait_for(self: &Arc<Self>, val: E) {
         let (mut stream, sub) = self.clone().subscribe_unbounded();
 

--- a/src/digital_io.rs
+++ b/src/digital_io.rs
@@ -22,6 +22,7 @@ use async_std::task::spawn;
 use crate::broker::{BrokerBuilder, Topic};
 use crate::led::BlinkPattern;
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod gpio {
     mod test;

--- a/src/ui/screens/setup.rs
+++ b/src/ui/screens/setup.rs
@@ -116,7 +116,7 @@ impl ActivatableScreen for SetupScreen {
         spawn(async move {
             while let Some(ips) = ip_stream.next().await {
                 connectivity_topic_task.modify(|prev| {
-                    let ip = ips.get(0).cloned();
+                    let ip = ips.first().cloned();
 
                     match (prev.unwrap(), ip) {
                         (Connectivity::Nothing, Some(ip)) | (Connectivity::IpOnly(_), Some(ip)) => {

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -117,7 +117,7 @@ impl ActivatableScreen for SystemScreen {
                 display,
                 row_anchor(3),
                 Box::new(|ips: &Vec<String>| {
-                    let ip = ips.get(0).map(|s| s.as_str()).unwrap_or("-");
+                    let ip = ips.first().map(|s| s.as_str()).unwrap_or("-");
                     format!("IP:     {}", ip)
                 }),
             )

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -27,6 +27,7 @@ import Spinner from "@cloudscape-design/components/spinner";
 import Wizard from "@cloudscape-design/components/wizard";
 
 import { LabgridService, LabgridConfig } from "./SettingsLabgrid";
+import { MqttToggle } from "./MqttComponents";
 import { ConfigEditor } from "./ConfigEditor";
 import { useMqttState } from "./mqtt";
 
@@ -127,6 +128,38 @@ export default function Setup() {
                         the Linux Automation GmbH team
                       </Box>
                     </SpaceBetween>
+                  </Container>
+                ),
+              },
+              {
+                title: "Configure Software Updates",
+                description:
+                  "Choose when and how to check for new software releases",
+                content: (
+                  <Container>
+                    <Box variant="p">
+                      The LXA TAC uses <Link href="https://rauc.io/">RAUC</Link>{" "}
+                      to manage and install software updates. A RAUC software
+                      update updates all of the installed software components at
+                      once and falls back to the previous version if something
+                      went wrong.
+                    </Box>
+                    <Box variant="p">
+                      We continually improve the software experience on the TAC
+                      and ship new features, so make sure to stay up to date
+                      with new releases.
+                    </Box>
+                    <Box variant="p">
+                      Would you like the TAC to periodically connect to the
+                      update server and check for software updates? You will be
+                      notified about updates via the LXA TACs display and the
+                      web interface and can start the update process from there.
+                    </Box>
+                    <Box variant="p" padding="s">
+                      <MqttToggle topic="/v1/tac/update/enable_polling">
+                        Periodically check for updates
+                      </MqttToggle>
+                    </Box>
                   </Container>
                 ),
               },

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -30,7 +30,7 @@ import SpaceBetween from "@cloudscape-design/components/space-between";
 import Spinner from "@cloudscape-design/components/spinner";
 import Table from "@cloudscape-design/components/table";
 
-import { MqttButton } from "./MqttComponents";
+import { MqttButton, MqttToggle } from "./MqttComponents";
 import { useMqttSubscription } from "./mqtt";
 
 type RootfsSlot = {
@@ -219,6 +219,30 @@ export function SlotStatus() {
       </SpaceBetween>
     );
   }
+}
+
+export function UpdateConfig() {
+  return (
+    <Container
+      header={
+        <Header
+          variant="h3"
+          description="Decide how updates are handled on this TAC"
+        >
+          Update Configuration
+        </Header>
+      }
+    >
+      <ColumnLayout columns={3} variant="text-grid">
+        <Box>
+          <Box variant="awsui-key-label">Update Polling</Box>
+          <MqttToggle topic="/v1/tac/update/enable_polling">
+            Periodically check for updates
+          </MqttToggle>
+        </Box>
+      </ColumnLayout>
+    </Container>
+  );
 }
 
 export function UpdateChannels() {
@@ -450,6 +474,7 @@ export function UpdateContainer() {
       }
     >
       <SpaceBetween size="m">
+        <UpdateConfig />
         <UpdateChannels />
         <SlotStatus />
       </SpaceBetween>

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -225,8 +225,13 @@ export function UpdateChannels() {
   const channels_topic = useMqttSubscription<Array<Channel>>(
     "/v1/tac/update/channels",
   );
+  const enable_polling_topic = useMqttSubscription<Array<Channel>>(
+    "/v1/tac/update/enable_polling",
+  );
 
   const channels = channels_topic !== undefined ? channels_topic : [];
+  const enable_polling =
+    enable_polling_topic !== undefined ? enable_polling_topic : false;
 
   return (
     <Table
@@ -260,7 +265,9 @@ export function UpdateChannels() {
         {
           id: "enabled",
           header: "Enabled",
-          cell: (e) => <Checkbox checked={e.enabled} />,
+          cell: (e) => (
+            <Checkbox checked={e.enabled} disabled={!enable_polling} />
+          ),
         },
         {
           id: "description",
@@ -276,8 +283,12 @@ export function UpdateChannels() {
         },
         {
           id: "interval",
-          header: "Update Interval",
+          header: "Polling Interval",
           cell: (e) => {
+            if (!enable_polling) {
+              return "Disabled";
+            }
+
             if (!e.polling_interval) {
               return "Never";
             }
@@ -313,7 +324,11 @@ export function UpdateChannels() {
             }
 
             if (!e.bundle) {
-              return <Spinner />;
+              if (enable_polling) {
+                return <Spinner />;
+              } else {
+                return "Polling disabled";
+              }
             }
 
             if (!e.bundle.newer_than_installed) {


### PR DESCRIPTION
Phoning home for software updates without asking for any kind of consent is bad practice and (rightfully) breaks user's trust.

So we shouldn't do it.

1) Add an endpoint to the `tacd`'s API that is persisted to disk and configures wether there should be polling for updates.
2) Add a page to the setup wizard that asks if the user wants to poll for updates.
3) Add a "Poll for updates yes/no" toggle to the Updating overview in the TAC Dashboard. And integrate the "should poll" information into the other widgets

The setup wizard page:

![Setup wizard polling config](https://github.com/linux-automation/tacd/assets/1273320/f7451bb3-7709-4500-b714-197791fb98b5)

The dashboard panel when update polling is enabled:

![Dashboard polling enabled](https://github.com/linux-automation/tacd/assets/1273320/8aca9929-78f7-4436-a8fa-43593bb8e68f)

The dashboard panel when update polling is disabled (and its effect on the "Channel Enabled" and "Channel Polling Interval" table columns):

![Dashboard polling disabled](https://github.com/linux-automation/tacd/assets/1273320/1d8e6aba-5521-48c2-a870-65f372455609)

Related Pull Requests
---------------

This PR is based on another PR that should be merged first:

- [x] tacd #51