### PR TITLE
ui: reduce idle brightness of the status led

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -161,7 +161,7 @@ impl Ui {
                     led_status_pattern.set(pattern_locator_on.clone());
                 } else {
                     // Green light when locator is off
-                    led_status_color.set((0.0, 1.0, 0.0));
+                    led_status_color.set((0.0, 0.23, 0.0));
                     led_status_pattern.set(pattern_locator_off.clone());
                 }
             }


### PR DESCRIPTION
The first hardware samples of LXA TACs with status LEDs showed them to be far to bright. Since then we have reduced the current through the "normal" (non-pwm) status LEDs by a factor of `33` in hardware. The brightness of the pwm LEDs was only reduced in hardware by a factor of `7.5`. This allows us to still make them light up quite brightly if we want them to.

In the idle state their brightness should however match the brightness of the other LEDs.

Dim them in software by a factor of `33/7.5 = 4.4`.