### PR TITLE
web: TacComponents: fix wrong notifications on disconnect

### DIFF
--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -608,7 +608,7 @@ export function UsbOverloadNotification() {
     <Alert
       statusIconAriaLabel="Warning"
       type="warning"
-      visible={overload !== null}
+      visible={overload !== undefined && overload !== null}
       header={header}
     >
       Disconnect {detail} or use a powered hub to resolve this issue.

--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -570,7 +570,7 @@ export function OverTemperatureNotification() {
     <Alert
       statusIconAriaLabel="Warning"
       type="warning"
-      visible={warning !== null && warning !== "Okay"}
+      visible={warning !== undefined && warning !== "Okay"}
       header="Your LXA TAC is overheating"
     >
       The LXA TAC's temperature is{" "}


### PR DESCRIPTION
This fixes the "Your LXA TAC is overheating" and "One of the USB ports is overloaded" error messages being shown when the web interface loses the connection to the TAC:

![conn-lost](https://github.com/linux-automation/tacd/assets/1273320/de328e35-9145-4813-accf-021554b7cadd)

This replaces #38, which tried to solve these errors in a way that felt more "correct" to me back then but cause lots of issues around the web interface that would need fixing.