### PR TITLE
rauc: wait two minutes after startup before polling for updates

### DIFF
--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -72,6 +72,7 @@ mod imports {
 }
 
 const RELOAD_RATE_LIMIT: Duration = Duration::from_secs(10 * 60);
+const STARTUP_DELAY: Duration = Duration::from_secs(2 * 60);
 
 use imports::*;
 
@@ -236,6 +237,13 @@ async fn channel_list_update_task(
 ) {
     let mut previous: Option<Instant> = None;
     let mut polling_tasks: Vec<JoinHandle<_>> = Vec::new();
+
+    // The tacd is usually started before the network connection is up.
+    // This means the first update polling request will nearly always fail.
+    // We could decide when the network is up based on some heuristic or
+    // based on what NetworkManager tells us.
+    // Or we can just wait a bit after startup.
+    sleep(STARTUP_DELAY).await;
 
     while let Some(reload) = reload_stream.next().await {
         if !reload {


### PR DESCRIPTION
The first poll for updates after a fresh boot usually fails, because the network is not yet up.
This means an update notification will only appear once one polling interval passed since startup (which can be on the order of days).
We could use a heuristic to decide once the network is up so we can start polling, but we are in no hurry and can just wait a bit before the first poll. "A bit" being two minutes in this case because it feels about.