### PR TITLE
ui: add button labels that tell the user which button does what

### DIFF
--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -134,31 +134,29 @@ pub(super) trait ActivatableScreen: Sync + Send {
 
 /// Draw static screen border containing a title and an indicator for the
 /// position of the screen in the list of screens.
-fn draw_border(text: &str, screen: NormalScreen, display: &Display) {
-    display.with_lock(|target| {
-        Text::new(
-            text,
-            Point::new(8, 17),
-            MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
-        )
+fn draw_border(target: &mut DisplayExclusive, text: &str, screen: NormalScreen) {
+    Text::new(
+        text,
+        Point::new(8, 17),
+        MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On),
+    )
+    .draw(target)
+    .unwrap();
+
+    Line::new(Point::new(0, 23), Point::new(240, 23))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
         .draw(target)
         .unwrap();
 
-        Line::new(Point::new(0, 24), Point::new(240, 24))
-            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 2))
-            .draw(target)
-            .unwrap();
+    let screen_idx = screen as i32;
+    let num_screens = (NormalScreen::Uart as i32) + 1;
+    let x_start = screen_idx * 240 / num_screens;
+    let x_end = (screen_idx + 1) * 240 / num_screens;
 
-        let screen_idx = screen as i32;
-        let num_screens = (NormalScreen::Uart as i32) + 1;
-        let x_start = screen_idx * 240 / num_screens;
-        let x_end = (screen_idx + 1) * 240 / num_screens;
-
-        Line::new(Point::new(x_start, 240), Point::new(x_end, 240))
-            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
-            .draw(target)
-            .unwrap();
-    });
+    Line::new(Point::new(x_start, 240), Point::new(x_end, 240))
+        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 4))
+        .draw(target)
+        .unwrap();
 }
 
 const fn row_anchor(row_num: u8) -> Point {

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -60,8 +60,6 @@ impl ActivatableScreen for DigOutScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("Digital Out", SCREEN_TYPE, &display);
-
         let ports = [
             (
                 0,
@@ -81,6 +79,8 @@ impl ActivatableScreen for DigOutScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_border(target, "Digital Out", SCREEN_TYPE);
+
             for (idx, name, _, _) in ports {
                 let anchor_name = row_anchor(idx * 4);
 

--- a/src/ui/screens/dig_out.rs
+++ b/src/ui/screens/dig_out.rs
@@ -33,7 +33,7 @@ const SCREEN_TYPE: NormalScreen = NormalScreen::DigOut;
 const VOLTAGE_MAX: f32 = 5.0;
 const OFFSET_INDICATOR: Point = Point::new(170, -10);
 const OFFSET_BAR: Point = Point::new(140, -14);
-const WIDTH_BAR: u32 = 72;
+const WIDTH_BAR: u32 = 62;
 const HEIGHT_BAR: u32 = 18;
 
 pub struct DigOutScreen {
@@ -80,6 +80,7 @@ impl ActivatableScreen for DigOutScreen {
 
         display.with_lock(|target| {
             draw_border(target, "Digital Out", SCREEN_TYPE);
+            draw_button_legend(target, "Action", "Screen");
 
             for (idx, name, _, _) in ports {
                 let anchor_name = row_anchor(idx * 4);

--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -96,6 +96,8 @@ impl ActivatableScreen for HelpScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        display.with_lock(|target| draw_button_legend(target, "Action", "Leave"));
+
         let mut widgets = WidgetContainer::new(display);
 
         let up = Topic::anonymous(Some(false));

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -56,6 +56,7 @@ impl ActivatableScreen for IoBusScreen {
 
         display.with_lock(|target| {
             draw_border(target, "IOBus", SCREEN_TYPE);
+            draw_button_legend(target, "Toggle", "Screen");
 
             Text::new("CAN Status:", row_anchor(0), ui_text_style)
                 .draw(target)

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -56,7 +56,6 @@ impl ActivatableScreen for IoBusScreen {
 
         display.with_lock(|target| {
             draw_border(target, "IOBus", SCREEN_TYPE);
-            draw_button_legend(target, "Toggle", "Screen");
 
             Text::new("CAN Status:", row_anchor(0), ui_text_style)
                 .draw(target)
@@ -131,6 +130,21 @@ impl ActivatableScreen for IoBusScreen {
                     true => IndicatorState::On,
                     false => IndicatorState::Off,
                 }),
+            )
+        });
+
+        widgets.push(|display| {
+            DynamicWidget::button_legend(
+                ui.res.regulators.iobus_pwr_en.clone(),
+                display,
+                |state: &bool| {
+                    let lower = match *state {
+                        false => "Turn On",
+                        true => "Turn Off",
+                    };
+
+                    (lower.into(), "Screen".into())
+                },
             )
         });
 

--- a/src/ui/screens/iobus.rs
+++ b/src/ui/screens/iobus.rs
@@ -51,12 +51,12 @@ impl ActivatableScreen for IoBusScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("IOBus", SCREEN_TYPE, &display);
-
         let ui_text_style: MonoTextStyle<BinaryColor> =
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_border(target, "IOBus", SCREEN_TYPE);
+
             Text::new("CAN Status:", row_anchor(0), ui_text_style)
                 .draw(target)
                 .unwrap();

--- a/src/ui/screens/iobus_health.rs
+++ b/src/ui/screens/iobus_health.rs
@@ -76,6 +76,8 @@ impl ActivatableScreen for IoBusHealthScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_button_legend(target, "Dismiss", "-");
+
             Text::new(
                 "IOBus supply overload",
                 row_anchor(0) - (row_anchor(1) - row_anchor(0)),

--- a/src/ui/screens/locator.rs
+++ b/src/ui/screens/locator.rs
@@ -81,6 +81,8 @@ impl ActivatableScreen for LocatorScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_button_legend(target, "Found it!", "-");
+
             Text::with_alignment(
                 "Locating this TAC",
                 Point::new(120, 80),

--- a/src/ui/screens/overtemperature.rs
+++ b/src/ui/screens/overtemperature.rs
@@ -75,6 +75,9 @@ impl ActivatableScreen for OverTemperatureScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            // This screen can only be left by resolving the underlying issue
+            draw_button_legend(target, "-", "-");
+
             Text::new("Temperature alert!", row_anchor(0), ui_text_style)
                 .draw(target)
                 .unwrap();

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -33,7 +33,7 @@ const CURRENT_LIMIT: f32 = 5.0;
 const VOLTAGE_LIMIT: f32 = 48.0;
 const OFFSET_INDICATOR: Point = Point::new(155, -10);
 const OFFSET_BAR: Point = Point::new(112, -14);
-const WIDTH_BAR: u32 = 100;
+const WIDTH_BAR: u32 = 90;
 const HEIGHT_BAR: u32 = 18;
 
 pub struct PowerScreen;
@@ -56,7 +56,10 @@ impl ActivatableScreen for PowerScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        display.with_lock(|target| draw_border(target, "DUT Power", SCREEN_TYPE));
+        display.with_lock(|target| {
+            draw_border(target, "DUT Power", SCREEN_TYPE);
+            draw_button_legend(target, "Toggle", "Screen");
+        });
 
         let mut widgets = WidgetContainer::new(display);
 

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -56,10 +56,7 @@ impl ActivatableScreen for PowerScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        display.with_lock(|target| {
-            draw_border(target, "DUT Power", SCREEN_TYPE);
-            draw_button_legend(target, "Toggle", "Screen");
-        });
+        display.with_lock(|target| draw_border(target, "DUT Power", SCREEN_TYPE));
 
         let mut widgets = WidgetContainer::new(display);
 
@@ -132,6 +129,21 @@ impl ActivatableScreen for PowerScreen {
                     OutputState::Changing => IndicatorState::Unkown,
                     _ => IndicatorState::Error,
                 }),
+            )
+        });
+
+        widgets.push(|display| {
+            DynamicWidget::button_legend(
+                ui.res.dut_pwr.state.clone(),
+                display,
+                |state: &OutputState| {
+                    let lower = match state {
+                        OutputState::On => "Turn Off",
+                        _ => "Turn On",
+                    };
+
+                    (lower.into(), "Screen".into())
+                },
             )
         });
 

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -56,7 +56,7 @@ impl ActivatableScreen for PowerScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("DUT Power", SCREEN_TYPE, &display);
+        display.with_lock(|target| draw_border(target, "DUT Power", SCREEN_TYPE));
 
         let mut widgets = WidgetContainer::new(display);
 

--- a/src/ui/screens/power_fail.rs
+++ b/src/ui/screens/power_fail.rs
@@ -99,6 +99,8 @@ impl ActivatableScreen for PowerFailScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_button_legend(target, "Select", "-");
+
             Text::new(
                 "DUT Power error",
                 row_anchor(0) - (row_anchor(1) - row_anchor(0)),
@@ -121,12 +123,16 @@ impl ActivatableScreen for PowerFailScreen {
                             "The error was resolved"
                         }
                         OutputState::InvertedPolarity => {
-                            "Output disabled due to\ninverted polarity."
+                            "Output disabled due\nto inverted polarity."
                         }
-                        OutputState::OverCurrent => "DUT powered off due to\nan overcurrent event.",
-                        OutputState::OverVoltage => "DUT powered off due to\nan overvoltage event.",
+                        OutputState::OverCurrent => {
+                            "DUT powered off due\nto an overcurrent\nevent."
+                        }
+                        OutputState::OverVoltage => {
+                            "DUT powered off due\nto an overvoltage\nevent."
+                        }
                         OutputState::RealtimeViolation => {
-                            "Output disabled due to\na realtime violation."
+                            "Output disabled due\n to a realtime\nviolation."
                         }
                         OutputState::Changing => "",
                     };
@@ -145,8 +151,8 @@ impl ActivatableScreen for PowerFailScreen {
                 row_anchor(6),
                 Box::new(|highlight: &Highlight| {
                     let msg = match highlight {
-                        Highlight::TurnOn => "> Turn output back on\n  Keep output off",
-                        Highlight::KeepOff => "  Turn output back on\n> Keep output off",
+                        Highlight::TurnOn => "> Turn back on\n  Keep output off",
+                        Highlight::KeepOff => "  Turn back on\n> Keep output off",
                     };
 
                     msg.to_string()

--- a/src/ui/screens/reboot.rs
+++ b/src/ui/screens/reboot.rs
@@ -71,7 +71,9 @@ fn rly(text: &str, display: &Display) {
     let text_style: MonoTextStyle<BinaryColor> = MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
     display.with_lock(|target| {
-        Text::with_alignment(text, Point::new(120, 80), text_style, Alignment::Center)
+        draw_button_legend(target, "Reboot", "Dismiss");
+
+        Text::with_alignment(text, Point::new(115, 80), text_style, Alignment::Center)
             .draw(target)
             .unwrap()
     });
@@ -135,7 +137,8 @@ impl ActiveScreen for Active {
 
     fn input(&mut self, ev: InputEvent) {
         match ev {
-            InputEvent::NextScreen | InputEvent::ToggleAction(_) => self.reboot_message.set(None),
+            InputEvent::NextScreen => self.reboot_message.set(None),
+            InputEvent::ToggleAction(_) => {}
             InputEvent::PerformAction(_) => {
                 brb(&self.display);
                 self.reboot.set(true);

--- a/src/ui/screens/screensaver.rs
+++ b/src/ui/screens/screensaver.rs
@@ -135,9 +135,11 @@ impl ActivatableScreen for ScreenSaverScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        display.with_lock(|target| draw_button_legend(target, "Locator", "Wake Up"));
+
         let bounce = BounceAnimation::new(Rectangle::with_corners(
             Point::new(0, 8),
-            Point::new(240, 240),
+            Point::new(223, 240),
         ));
 
         let mut widgets = WidgetContainer::new(display);

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -73,7 +73,7 @@ impl ActivatableScreen for SystemScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("System Status", SCREEN_TYPE, &display);
+        display.with_lock(|target| draw_border(target, "System Status", SCREEN_TYPE));
 
         let mut widgets = WidgetContainer::new(display);
         let highlighted = Topic::anonymous(Some(Action::Reboot));

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -73,7 +73,10 @@ impl ActivatableScreen for SystemScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        display.with_lock(|target| draw_border(target, "System Status", SCREEN_TYPE));
+        display.with_lock(|target| {
+            draw_border(target, "System Status", SCREEN_TYPE);
+            draw_button_legend(target, "Action", "Screen")
+        });
 
         let mut widgets = WidgetContainer::new(display);
         let highlighted = Topic::anonymous(Some(Action::Reboot));

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -83,7 +83,7 @@ impl ActivatableScreen for SystemScreen {
                 ui.res.temperatures.soc_temperature.clone(),
                 display,
                 row_anchor(0),
-                Box::new(|meas: &Measurement| format!("SoC:    {:.0}C", meas.value)),
+                Box::new(|meas: &Measurement| format!("SoC: {:.0}C", meas.value)),
             )
         });
 
@@ -93,8 +93,8 @@ impl ActivatableScreen for SystemScreen {
                 display,
                 row_anchor(1),
                 Box::new(|info: &LinkInfo| match info.carrier {
-                    true => format!("Uplink: {}MBit/s", info.speed),
-                    false => "Uplink: Down".to_string(),
+                    true => format!("UL:  {}MBit/s", info.speed),
+                    false => "UL:  Down".to_string(),
                 }),
             )
         });
@@ -105,8 +105,8 @@ impl ActivatableScreen for SystemScreen {
                 display,
                 row_anchor(2),
                 Box::new(|info: &LinkInfo| match info.carrier {
-                    true => format!("DUT:    {}MBit/s", info.speed),
-                    false => "DUT:    Down".to_string(),
+                    true => format!("DUT: {}MBit/s", info.speed),
+                    false => "DUT: Down".to_string(),
                 }),
             )
         });
@@ -118,7 +118,7 @@ impl ActivatableScreen for SystemScreen {
                 row_anchor(3),
                 Box::new(|ips: &Vec<String>| {
                     let ip = ips.first().map(|s| s.as_str()).unwrap_or("-");
-                    format!("IP:     {}", ip)
+                    format!("IP:  {}", ip)
                 }),
             )
         });

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -51,7 +51,7 @@ impl ActivatableScreen for UartScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("DUT UART", SCREEN_TYPE, &display);
+        display.with_lock(|target| draw_border(target, "DUT UART", SCREEN_TYPE));
 
         let mut widgets = WidgetContainer::new(display);
 

--- a/src/ui/screens/uart.rs
+++ b/src/ui/screens/uart.rs
@@ -51,7 +51,10 @@ impl ActivatableScreen for UartScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        display.with_lock(|target| draw_border(target, "DUT UART", SCREEN_TYPE));
+        display.with_lock(|target| {
+            draw_border(target, "DUT UART", SCREEN_TYPE);
+            draw_button_legend(target, "Action", "Screen")
+        });
 
         let mut widgets = WidgetContainer::new(display);
 

--- a/src/ui/screens/update_available.rs
+++ b/src/ui/screens/update_available.rs
@@ -181,6 +181,8 @@ impl ActivatableScreen for UpdateAvailableScreen {
                 self.selection.clone(),
                 display,
                 Box::new(move |sel, target| {
+                    draw_button_legend(target, "Select", "-");
+
                     let ui_text_style: MonoTextStyle<BinaryColor> =
                         MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 

--- a/src/ui/screens/update_installation.rs
+++ b/src/ui/screens/update_installation.rs
@@ -90,6 +90,10 @@ impl ActivatableScreen for UpdateInstallationScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        // This screen is left automatically once the update is complete.
+        // No way to exit it prior to that.
+        display.with_lock(|target| draw_button_legend(target, "-", "-"));
+
         let mut widgets = WidgetContainer::new(display);
 
         widgets.push(|display| {

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -61,12 +61,12 @@ impl ActivatableScreen for UsbScreen {
     }
 
     fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
-        draw_border("USB Host", SCREEN_TYPE, &display);
-
         let ui_text_style: MonoTextStyle<BinaryColor> =
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            draw_border(target, "USB Host", SCREEN_TYPE);
+
             Text::new("Total", row_anchor(0), ui_text_style)
                 .draw(target)
                 .unwrap();

--- a/src/ui/screens/usb.rs
+++ b/src/ui/screens/usb.rs
@@ -33,7 +33,7 @@ use crate::usb_hub::{MAX_PORT_CURRENT, MAX_TOTAL_CURRENT};
 const SCREEN_TYPE: NormalScreen = NormalScreen::Usb;
 const OFFSET_INDICATOR: Point = Point::new(92, -10);
 const OFFSET_BAR: Point = Point::new(122, -14);
-const WIDTH_BAR: u32 = 90;
+const WIDTH_BAR: u32 = 80;
 const HEIGHT_BAR: u32 = 18;
 
 pub struct UsbScreen {
@@ -66,6 +66,7 @@ impl ActivatableScreen for UsbScreen {
 
         display.with_lock(|target| {
             draw_border(target, "USB Host", SCREEN_TYPE);
+            draw_button_legend(target, "Action", "Screen");
 
             Text::new("Total", row_anchor(0), ui_text_style)
                 .draw(target)

--- a/src/ui/screens/usb_overload.rs
+++ b/src/ui/screens/usb_overload.rs
@@ -35,8 +35,8 @@ use crate::watched_tasks::WatchedTasksBuilder;
 
 const SCREEN_TYPE: AlertScreen = AlertScreen::UsbOverload;
 const OFFSET_BAR: Point = Point::new(75, -14);
-const OFFSET_VAL: Point = Point::new(160, 0);
-const WIDTH_BAR: u32 = 80;
+const OFFSET_VAL: Point = Point::new(145, 0);
+const WIDTH_BAR: u32 = 65;
 const HEIGHT_BAR: u32 = 18;
 
 pub struct UsbOverloadScreen;
@@ -80,6 +80,9 @@ impl ActivatableScreen for UsbOverloadScreen {
             MonoTextStyle::new(&UI_TEXT_FONT, BinaryColor::On);
 
         display.with_lock(|target| {
+            // This screen can only be left by resolving the underlying issue
+            draw_button_legend(target, "-", "-");
+
             Text::new(
                 "USB Power Overload",
                 row_anchor(0) - (row_anchor(1) - row_anchor(0)),

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -318,6 +318,27 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
         )
     }
 
+    /// Draw a dynamic button legend
+    ///
+    /// Sometimes you want to draw different button legend text based on
+    /// external input. For example change from "Turn On" to "Turn Off" when
+    /// the status of the controlled value changes.
+    pub fn button_legend(
+        topic: Arc<Topic<T>>,
+        display: Arc<Display>,
+        format_fn: fn(&T) -> (String, String),
+    ) -> Self {
+        Self::new(
+            topic,
+            display,
+            Box::new(move |msg, target| {
+                let (lower, upper) = format_fn(msg);
+
+                Some(draw_button_legend(target, &lower, &upper))
+            }),
+        )
+    }
+
     /// Draw self-updating text with configurable alignment
     pub fn text_aligned(
         topic: Arc<Topic<T>>,


### PR DESCRIPTION
This adds a little legend on the right of the screen (where the two buttons are) that tells the user what which button does what:

<img alt="dig_out" src="https://github.com/linux-automation/tacd/assets/1273320/d3c7d96c-3c0d-413e-a15c-539208f4f411" width="23%">
<img alt="iobus" src="https://github.com/linux-automation/tacd/assets/1273320/a2e37213-824e-4693-b566-f67e03b1ed2c" width="23%">
<img alt="iobus_health" src="https://github.com/linux-automation/tacd/assets/1273320/e0750b5b-356c-4be4-8bde-b3f73e0face7" width="23%">
<img alt="locator" src="https://github.com/linux-automation/tacd/assets/1273320/1db44902-6b53-4f30-86f8-4690c1634821" width="23%">
<img alt="overtemperature" src="https://github.com/linux-automation/tacd/assets/1273320/fab8de49-330c-4ef8-87f5-42992d4757d4" width="23%">
<img alt="power" src="https://github.com/linux-automation/tacd/assets/1273320/6a5907a5-13cc-467a-bca7-2f35eef61306" width="23%">
<img alt="power_fail" src="https://github.com/linux-automation/tacd/assets/1273320/2d4ef94c-4cbb-4ba3-a467-834a3586cfd7" width="23%">
<img alt="reboot" src="https://github.com/linux-automation/tacd/assets/1273320/9c3f1cd8-72ce-4ce6-81b9-a4ae63c956c0" width="23%">
<img alt="screensaver" src="https://github.com/linux-automation/tacd/assets/1273320/cbb9cf6a-a19d-4538-bf31-810e9d4f6072" width="23%">
<img alt="system" src="https://github.com/linux-automation/tacd/assets/1273320/852f5977-0c3a-4393-a17a-e589125810fe" width="23%">
<img alt="uart" src="https://github.com/linux-automation/tacd/assets/1273320/70f2a03e-1664-4d7a-85f6-a200b49b43f5" width="23%">
<img alt="update_available" src="https://github.com/linux-automation/tacd/assets/1273320/1363c658-3676-479e-b64f-565efe104a7b" width="23%">
<img alt="update_installing" src="https://github.com/linux-automation/tacd/assets/1273320/3899198c-6d31-4294-bbed-a06104dc4318" width="23%">
<img alt="usb" src="https://github.com/linux-automation/tacd/assets/1273320/4e4e2813-70e2-4449-a508-83713de71f08" width="23%">
<img alt="usb_overload" src="https://github.com/linux-automation/tacd/assets/1273320/d898f6bd-65cf-4c6c-b755-348f2e89b6ee" width="23%">
<img alt="reboot_slot" src="https://github.com/linux-automation/tacd/assets/1273320/53c62834-6b2e-4e6c-a305-85c97a35c90d" width="23%">


TODO before merging:

  - [x] Add comments to the drawing routine that make it easier to read
  - [x] Add comments to the screen rotation trickery
  - [x] Add legends to alert screens as well