### PR TITLE
dut_power: implement an error-free grace period after DUT power on

### DIFF
--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -413,45 +413,47 @@ impl DutPwrThread {
                     .swap(OutputRequest::Idle as u8, Ordering::Relaxed)
                     .into();
 
-                // Don't even look at the requests if there is an ongoing
-                // overvoltage condition. Instead turn the output off and
-                // go back to measuring.
-                if volt > MAX_VOLTAGE {
-                    turn_off_with_reason(
-                        OutputState::OverVoltage,
-                        &pwr_line,
-                        &discharge_line,
-                        &state,
-                    );
+                {
+                    // Don't even look at the requests if there is an ongoing
+                    // overvoltage condition. Instead turn the output off and
+                    // go back to measuring.
+                    if volt > MAX_VOLTAGE {
+                        turn_off_with_reason(
+                            OutputState::OverVoltage,
+                            &pwr_line,
+                            &discharge_line,
+                            &state,
+                        );
 
-                    continue;
-                }
+                        continue;
+                    }
 
-                // Don't even look at the requests if there is an ongoin
-                // polarity inversion. Turn off, go back to start, do not
-                // collect $200.
-                if volt < MIN_VOLTAGE {
-                    turn_off_with_reason(
-                        OutputState::InvertedPolarity,
-                        &pwr_line,
-                        &discharge_line,
-                        &state,
-                    );
+                    // Don't even look at the requests if there is an ongoin
+                    // polarity inversion. Turn off, go back to start, do not
+                    // collect $200.
+                    if volt < MIN_VOLTAGE {
+                        turn_off_with_reason(
+                            OutputState::InvertedPolarity,
+                            &pwr_line,
+                            &discharge_line,
+                            &state,
+                        );
 
-                    continue;
-                }
+                        continue;
+                    }
 
-                // Don't even look at the requests if there is an ongoin
-                // overcurrent condition.
-                if curr > MAX_CURRENT {
-                    turn_off_with_reason(
-                        OutputState::OverCurrent,
-                        &pwr_line,
-                        &discharge_line,
-                        &state,
-                    );
+                    // Don't even look at the requests if there is an ongoin
+                    // overcurrent condition.
+                    if curr > MAX_CURRENT {
+                        turn_off_with_reason(
+                            OutputState::OverCurrent,
+                            &pwr_line,
+                            &discharge_line,
+                            &state,
+                        );
 
-                    continue;
+                        continue;
+                    }
                 }
 
                 // There is no ongoing fault condition, so we could e.g. turn


### PR DESCRIPTION
This solves a problem we see with some DUTs and DUT power supplies where the DUT refuses to turn back on due to e.g. a persistent `PolarityInversion` error.

These errors are caused by leakage currents from the DUT power supply interfering with our high impedance voltage measurement. These currents result in actual measurable voltages on the DUT power switch output pins, which are measured by the ADC and interpreted as erroneous.

This PR ignores voltage measurements that would normally result in overvoltage / undervoltage / overcurrent errors _while the power supply is already off_ and also shortly after turning it on (to give the measurements some time to settle).
It should thus not impact our goal of protecting the DUT from actual overvoltages, inverted polarities and overcurrent events, because the turn-on is only a transient event and while the switch is already off there is nothing we could do to protected the device even more.

I would like to split the reviewing process on this PR into two:

  - @SmithChart should review if the intent matches what we want to achieve
  - @KarlK90 should review if the code matches the intent