### PR TITLE
Fix cargo check errors that were added in nightly cargo

### DIFF
--- a/src/backlight.rs
+++ b/src/backlight.rs
@@ -20,6 +20,7 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use log::warn;
 
+#[cfg(feature = "demo_mode")]
 mod demo_mode;
 
 #[cfg(feature = "demo_mode")]

--- a/src/broker/mqtt_conn.rs
+++ b/src/broker/mqtt_conn.rs
@@ -40,7 +40,6 @@ use futures_util::future::Either;
 use futures_util::{FutureExt, SinkExt, StreamExt};
 
 use mqtt::control::variable_header::{ConnectReturnCode, ProtocolLevel};
-use mqtt::packet::publish::QoSWithPacketIdentifier;
 use mqtt::packet::suback::SubscribeReturnCode;
 use mqtt::TopicFilter;
 use mqtt::{packet::*, Decodable, Encodable};

--- a/src/dbus/networkmanager.rs
+++ b/src/dbus/networkmanager.rs
@@ -16,7 +16,6 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 use anyhow::Result;
-use async_std;
 use async_std::sync::Arc;
 use serde::{Deserialize, Serialize};
 

--- a/src/led.rs
+++ b/src/led.rs
@@ -25,7 +25,9 @@ use log::{error, info, warn};
 use crate::broker::{BrokerBuilder, Topic};
 use crate::watched_tasks::WatchedTasksBuilder;
 
+#[cfg(feature = "demo_mode")]
 mod demo_mode;
+
 mod extras;
 
 #[cfg(feature = "demo_mode")]


### PR DESCRIPTION
Nightly rust has learned some new tricks to detect dead code and unused imports, which is quite cool.

A bit less cool is that this makes out CI runs fail right now. See [this one](https://github.com/linux-automation/tacd/actions/runs/8019854353/job/21908471258?pr=58) from PR #58 for example.

Fix these new errors by making some imports conditional and removing others.