### PR TITLE
web: labgrid configuration

### DIFF
--- a/web/src/SettingsLabgrid.tsx
+++ b/web/src/SettingsLabgrid.tsx
@@ -48,7 +48,7 @@ export function LabgridConfig() {
           label: "User Config",
           id: "user",
           content: (
-            <ConfigEditor path="/v1/labgrid/userconfig" language="yaml" />
+            <ConfigEditor path="/v1/labgrid/userconfig" language="text" />
           ),
         },
         {
@@ -62,7 +62,7 @@ export function LabgridConfig() {
           label: "System Config",
           id: "system",
           content: (
-            <ConfigEditor path="v1/labgrid/configuration" language="yaml" />
+            <ConfigEditor path="v1/labgrid/configuration" language="text" />
           ),
         },
       ]}

--- a/web/src/Setup.tsx
+++ b/web/src/Setup.tsx
@@ -243,6 +243,10 @@ export default function Setup() {
                         Go back to the exporter configuration step to make
                         changes and click "Next" once you are satisfied.
                       </Box>
+                      <Box variant="p">
+                        If your labgrid configuration does not work right away
+                        you can always come back and change it later.
+                      </Box>
                       <LabgridService />
                     </SpaceBetween>
                   </Container>


### PR DESCRIPTION
This PR addresses some user feedback we got from our early access testers:

* Do not display the labgrid configurations with yaml-highlighting, since the Jinja2 in there causes spurious syntax errors.
* Add a note on the completion of the labgrid configuration to the wizard.