### PR TITLE
ui: help: Start first screen with a call to long-press 

### DIFF
--- a/src/ui/screens/help.rs
+++ b/src/ui/screens/help.rs
@@ -32,18 +32,25 @@ use crate::watched_tasks::WatchedTasksBuilder;
 const SCREEN_TYPE: AlertScreen = AlertScreen::Help;
 const PAGES: &[&str] = &[
     "Hey there!
-
 A short guide on how
 this interface works:
+
+Please long press the
+lower button to
+continue.
+...",
+    "...
+
 Long presses on the
 lower button perform
 actions.
+
 ...",
     "...
 
 Short presses on the
 lower button toggle
-between actions.
+between options.
 
 ...",
     "...
@@ -171,7 +178,7 @@ impl ActiveScreen for Active {
                 self.page.modify(|page| match (page.unwrap_or(0), up) {
                     (0, true) => Some(0),
                     (p, true) => Some(p - 1),
-                    (2, false) => Some(2),
+                    (3, false) => Some(3),
                     (p, false) => Some(p + 1),
                 });
             }


### PR DESCRIPTION
Showing users the help (aka quick-start) screen has shown that it's not
clear to everyone that they have to long-press the lower button to
actually switch to the next page of the help.

This change adds an explicit call-to-action to long-press the lower
button to the first page of help.
And afterwards explains what this has done.
This makes the help one page longer - but hopefully helps users discover
the long-press feature a little quicker.

To be merged after #56 .