### PR TITLE
broker: persistence: downgrade unknown keys in state file from err to warn

### DIFF
--- a/src/broker/persistence.rs
+++ b/src/broker/persistence.rs
@@ -22,7 +22,7 @@ use anyhow::{bail, Result};
 use async_std::channel::{unbounded, Receiver};
 use async_std::prelude::*;
 use async_std::sync::Arc;
-use log::{error, info};
+use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_writer_pretty, Map, Value};
 
@@ -70,12 +70,10 @@ fn load(topics: &[Arc<dyn AnyTopic>]) -> Result<()> {
     }
 
     if !content.is_empty() {
-        error!("State file contained extra keys:");
+        warn!("State file contained extra keys:");
         for topic_name in content.keys() {
-            error!(" - {topic_name}");
+            warn!(" - {topic_name}");
         }
-
-        bail!("Left over topics in state file");
     }
 
     Ok(())


### PR DESCRIPTION
This makes it so that a `tacd` will not fail to start if it encounters a state file that was written by a newer `tacd` version.

This means we actually have to use the versioning scheme we already have when a new persistence key e.g. has security implications that may not be lost in e.g. a new -> old -> new cycle.

Once such a change occurs we have the option to:

  - Increment the `format_version` field in the state file and make older `tacd`s fail to start that way.
  - Start writing changes to a new state file `/srv/tacd/state-v2.json` and also read from there if it exists, but fall back to the current path if it does not. This means old tacds keep reading the file they created and a new tacd will read from there and migrate.

But that's a problem for future us.

Right now just make sure that the `tacd` does not crash after an update.