### PR TITLE
 Add LXA TAC hardware generation 3 support (explicit generation detection)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -347,6 +347,21 @@ paths:
               schema:
                 type: string
 
+  /v1/tac/info/hardware_generation:
+    get:
+      summary: Get the LXA TAC hardware generation
+      tags: [System]
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+                enum:
+                  - Gen1
+                  - Gen2
+                  - Gen3
+
   /v1/tac/setup_mode:
     get:
       summary: Check if the TAC has completed the set up or is still in setup mode

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -85,7 +85,7 @@ impl Adc {
         hardware_generation: HardwareGeneration,
     ) -> Result<Self> {
         let stm32_thread = IioThread::new_stm32(wtb, hardware_generation).await?;
-        let powerboard_thread = IioThread::new_powerboard(wtb).await?;
+        let powerboard_thread = IioThread::new_powerboard(wtb, hardware_generation).await?;
 
         let adc = Self {
             usb_host_curr: AdcChannel {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -23,6 +23,7 @@ use async_std::task::sleep;
 
 use crate::broker::{BrokerBuilder, Topic};
 use crate::measurement::{Measurement, Timestamp};
+use crate::system::HardwareGeneration;
 use crate::watched_tasks::WatchedTasksBuilder;
 
 const HISTORY_LENGTH: usize = 200;
@@ -78,8 +79,12 @@ pub struct Adc {
 }
 
 impl Adc {
-    pub async fn new(bb: &mut BrokerBuilder, wtb: &mut WatchedTasksBuilder) -> Result<Self> {
-        let stm32_thread = IioThread::new_stm32(wtb).await?;
+    pub async fn new(
+        bb: &mut BrokerBuilder,
+        wtb: &mut WatchedTasksBuilder,
+        hardware_generation: HardwareGeneration,
+    ) -> Result<Self> {
+        let stm32_thread = IioThread::new_stm32(wtb, hardware_generation).await?;
         let powerboard_thread = IioThread::new_powerboard(wtb).await?;
 
         let adc = Self {

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -160,7 +160,7 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    pub async fn new_stm32<W>(_wtb: &W) -> Result<Arc<Self>> {
+    pub async fn new_stm32<W, G>(_wtb: &W, _hardware_generation: G) -> Result<Arc<Self>> {
         let mut demo_magic = block_on(DEMO_MAGIC_STM32.lock());
 
         // Only ever set up a single demo_mode "IioThread" per ADC

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -195,7 +195,7 @@ impl IioThread {
         Ok(this)
     }
 
-    pub async fn new_powerboard<W>(_wtb: &W) -> Result<Arc<Self>> {
+    pub async fn new_powerboard<W, G>(_wtb: &W, _hardware_generation: G) -> Result<Arc<Self>> {
         let mut demo_magic = block_on(DEMO_MAGIC_POWERBOARD.lock());
 
         // Only ever set up a single demo_mode "IioThread" per ADC

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -35,115 +35,9 @@ use crate::measurement::{Measurement, Timestamp};
 use crate::system::HardwareGeneration;
 use crate::watched_tasks::WatchedTasksBuilder;
 
-struct ChannelDesc {
-    kernel_name: &'static str,
-    calibration_path: &'static str,
-    name: &'static str,
-}
+mod channels;
 
-// Hard coded list of channels using the internal STM32MP1 ADC.
-// Consists of the IIO channel name, the location of the calibration data
-// in the device tree and an internal name for the channel.
-const CHANNELS_STM32_GEN1_GEN2: &[ChannelDesc] = &[
-    ChannelDesc {
-        kernel_name: "voltage13",
-        calibration_path: "baseboard-factory-data/usb-host-curr",
-        name: "usb-host-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage15",
-        calibration_path: "baseboard-factory-data/usb-host1-curr",
-        name: "usb-host1-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage0",
-        calibration_path: "baseboard-factory-data/usb-host2-curr",
-        name: "usb-host2-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage1",
-        calibration_path: "baseboard-factory-data/usb-host3-curr",
-        name: "usb-host3-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage2",
-        calibration_path: "baseboard-factory-data/out0-volt",
-        name: "out0-volt",
-    },
-    ChannelDesc {
-        kernel_name: "voltage10",
-        calibration_path: "baseboard-factory-data/out1-volt",
-        name: "out1-volt",
-    },
-    ChannelDesc {
-        kernel_name: "voltage5",
-        calibration_path: "baseboard-factory-data/iobus-curr",
-        name: "iobus-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage9",
-        calibration_path: "baseboard-factory-data/iobus-volt",
-        name: "iobus-volt",
-    },
-];
-
-const CHANNELS_STM32_GEN3: &[ChannelDesc] = &[
-    ChannelDesc {
-        kernel_name: "voltage13",
-        calibration_path: "baseboard-factory-data/usb-host-curr",
-        name: "usb-host-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage15",
-        calibration_path: "baseboard-factory-data/usb-host1-curr",
-        name: "usb-host1-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage18",
-        calibration_path: "baseboard-factory-data/usb-host2-curr",
-        name: "usb-host2-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage14",
-        calibration_path: "baseboard-factory-data/usb-host3-curr",
-        name: "usb-host3-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage2",
-        calibration_path: "baseboard-factory-data/out0-volt",
-        name: "out0-volt",
-    },
-    ChannelDesc {
-        kernel_name: "voltage10",
-        calibration_path: "baseboard-factory-data/out1-volt",
-        name: "out1-volt",
-    },
-    ChannelDesc {
-        kernel_name: "voltage5",
-        calibration_path: "baseboard-factory-data/iobus-curr",
-        name: "iobus-curr",
-    },
-    ChannelDesc {
-        kernel_name: "voltage9",
-        calibration_path: "baseboard-factory-data/iobus-volt",
-        name: "iobus-volt",
-    },
-];
-
-// The same as for the STM32MP1 channels but for the discrete ADC on the power
-// board.
-const CHANNELS_PWR: &[ChannelDesc] = &[
-    ChannelDesc {
-        kernel_name: "voltage",
-        calibration_path: "powerboard-factory-data/pwr-volt",
-        name: "pwr-volt",
-    },
-    ChannelDesc {
-        kernel_name: "current",
-        calibration_path: "powerboard-factory-data/pwr-curr",
-        name: "pwr-curr",
-    },
-];
+use channels::{ChannelDesc, Channels};
 
 const TRIGGER_HR_PWR_DIR: &str = "/sys/kernel/config/iio/triggers/hrtimer/tacd-pwr";
 
@@ -479,10 +373,7 @@ impl IioThread {
         wtb: &mut WatchedTasksBuilder,
         hardware_generation: HardwareGeneration,
     ) -> Result<Arc<Self>> {
-        let channels = match hardware_generation {
-            HardwareGeneration::Gen1 | HardwareGeneration::Gen2 => CHANNELS_STM32_GEN1_GEN2,
-            HardwareGeneration::Gen3 => CHANNELS_STM32_GEN3,
-        };
+        let channels = hardware_generation.channels_stm32();
 
         Self::new(
             wtb,
@@ -496,12 +387,17 @@ impl IioThread {
         .await
     }
 
-    pub async fn new_powerboard(wtb: &mut WatchedTasksBuilder) -> Result<Arc<Self>> {
+    pub async fn new_powerboard(
+        wtb: &mut WatchedTasksBuilder,
+        hardware_generation: HardwareGeneration,
+    ) -> Result<Arc<Self>> {
         let hr_trigger_path = Path::new(TRIGGER_HR_PWR_DIR);
 
         if !hr_trigger_path.is_dir() {
             create_dir(hr_trigger_path)?;
         }
+
+        let channels = hardware_generation.channels_pwr();
 
         Self::new(
             wtb,
@@ -509,7 +405,7 @@ impl IioThread {
             "lmp92064",
             "tacd-pwr",
             20,
-            CHANNELS_PWR,
+            channels,
             1,
         )
         .await

--- a/src/adc/iio/hardware/channels.rs
+++ b/src/adc/iio/hardware/channels.rs
@@ -1,0 +1,139 @@
+use crate::system::HardwareGeneration;
+
+pub(super) struct ChannelDesc {
+    pub kernel_name: &'static str,
+    pub calibration_path: &'static str,
+    pub name: &'static str,
+}
+
+// Hard coded list of channels using the internal STM32MP1 ADC.
+// Consists of the IIO channel name, the location of the calibration data
+// in the device tree and an internal name for the channel.
+const CHANNELS_STM32_GEN1_GEN2: &[ChannelDesc] = &[
+    ChannelDesc {
+        kernel_name: "voltage13",
+        calibration_path: "baseboard-factory-data/usb-host-curr",
+        name: "usb-host-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage15",
+        calibration_path: "baseboard-factory-data/usb-host1-curr",
+        name: "usb-host1-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage0",
+        calibration_path: "baseboard-factory-data/usb-host2-curr",
+        name: "usb-host2-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage1",
+        calibration_path: "baseboard-factory-data/usb-host3-curr",
+        name: "usb-host3-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage2",
+        calibration_path: "baseboard-factory-data/out0-volt",
+        name: "out0-volt",
+    },
+    ChannelDesc {
+        kernel_name: "voltage10",
+        calibration_path: "baseboard-factory-data/out1-volt",
+        name: "out1-volt",
+    },
+    ChannelDesc {
+        kernel_name: "voltage5",
+        calibration_path: "baseboard-factory-data/iobus-curr",
+        name: "iobus-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage9",
+        calibration_path: "baseboard-factory-data/iobus-volt",
+        name: "iobus-volt",
+    },
+];
+
+const CHANNELS_STM32_GEN3: &[ChannelDesc] = &[
+    ChannelDesc {
+        kernel_name: "voltage13",
+        calibration_path: "baseboard-factory-data/usb-host-curr",
+        name: "usb-host-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage15",
+        calibration_path: "baseboard-factory-data/usb-host1-curr",
+        name: "usb-host1-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage18",
+        calibration_path: "baseboard-factory-data/usb-host2-curr",
+        name: "usb-host2-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage14",
+        calibration_path: "baseboard-factory-data/usb-host3-curr",
+        name: "usb-host3-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage2",
+        calibration_path: "baseboard-factory-data/out0-volt",
+        name: "out0-volt",
+    },
+    ChannelDesc {
+        kernel_name: "voltage10",
+        calibration_path: "baseboard-factory-data/out1-volt",
+        name: "out1-volt",
+    },
+    ChannelDesc {
+        kernel_name: "voltage5",
+        calibration_path: "baseboard-factory-data/iobus-curr",
+        name: "iobus-curr",
+    },
+    ChannelDesc {
+        kernel_name: "voltage9",
+        calibration_path: "baseboard-factory-data/iobus-volt",
+        name: "iobus-volt",
+    },
+];
+
+// The same as for the STM32MP1 channels but for the discrete ADC on the power
+// board.
+const CHANNELS_PWR: &[ChannelDesc] = &[
+    ChannelDesc {
+        kernel_name: "voltage",
+        calibration_path: "powerboard-factory-data/pwr-volt",
+        name: "pwr-volt",
+    },
+    ChannelDesc {
+        kernel_name: "current",
+        calibration_path: "powerboard-factory-data/pwr-curr",
+        name: "pwr-curr",
+    },
+];
+
+pub(super) trait Channels {
+    fn channels_stm32(&self) -> &'static [ChannelDesc];
+    fn channels_pwr(&self) -> &'static [ChannelDesc];
+}
+
+impl Channels for HardwareGeneration {
+    fn channels_stm32(&self) -> &'static [ChannelDesc] {
+        // LXA TAC hardware generation 3 has move some of the ADC channels around
+        // so that channel 0 and 1 are no longer used.
+        // Channel 0 and 1 are special in that they do not use the pinmuxing support
+        // of the STM32MP1 SoC.
+        // Instead they are always connected to the ADC.
+        // This causes issues when the ADC peripheral is put into stanby,
+        // because current will leak into these pins in that case.
+
+        match self {
+            HardwareGeneration::Gen1 | HardwareGeneration::Gen2 => CHANNELS_STM32_GEN1_GEN2,
+            HardwareGeneration::Gen3 => CHANNELS_STM32_GEN3,
+        }
+    }
+
+    fn channels_pwr(&self) -> &'static [ChannelDesc] {
+        // The pin assignment of the power board is currently independent from the
+        // hardware generation.
+        CHANNELS_PWR
+    }
+}

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -107,7 +107,7 @@ pub struct IioThread {
 }
 
 impl IioThread {
-    pub async fn new_stm32<W>(_wtb: &W) -> Result<Arc<Self>> {
+    pub async fn new_stm32<W, G>(_wtb: &W, _hardware_generation: G) -> Result<Arc<Self>> {
         let mut channels = Vec::new();
 
         for name in CHANNELS_STM32 {

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -117,7 +117,7 @@ impl IioThread {
         Ok(Arc::new(Self { channels }))
     }
 
-    pub async fn new_powerboard<W>(_wtb: &W) -> Result<Arc<Self>> {
+    pub async fn new_powerboard<W, G>(_wtb: &W, _hardware_generation: G) -> Result<Arc<Self>> {
         let mut channels = Vec::new();
 
         for name in CHANNELS_PWR {

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -32,7 +32,7 @@ impl LineHandle {
         // It is just a hack to let adc/iio/demo_mode.rs
         // communicate with this function so that toggling an output
         // has an effect on the measured values.
-        let iio_thread_stm32 = block_on(IioThread::new_stm32(&())).unwrap();
+        let iio_thread_stm32 = block_on(IioThread::new_stm32(&(), ())).unwrap();
         let iio_thread_pwr = block_on(IioThread::new_powerboard(&())).unwrap();
 
         match self.name.as_str() {

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -80,14 +80,6 @@ impl BitOr for LineRequestFlags {
     }
 }
 
-pub struct ChipDecoy;
-
-impl ChipDecoy {
-    pub fn label(&self) -> &'static str {
-        "demo_mode"
-    }
-}
-
 pub struct FindDecoy {
     name: String,
 }
@@ -101,10 +93,6 @@ impl FindDecoy {
         line_handle.set_value(initial).unwrap();
 
         Ok(line_handle)
-    }
-
-    pub fn chip(&self) -> ChipDecoy {
-        ChipDecoy
     }
 }
 

--- a/src/digital_io/gpio/demo_mode.rs
+++ b/src/digital_io/gpio/demo_mode.rs
@@ -33,7 +33,7 @@ impl LineHandle {
         // communicate with this function so that toggling an output
         // has an effect on the measured values.
         let iio_thread_stm32 = block_on(IioThread::new_stm32(&(), ())).unwrap();
-        let iio_thread_pwr = block_on(IioThread::new_powerboard(&())).unwrap();
+        let iio_thread_pwr = block_on(IioThread::new_powerboard(&(), ())).unwrap();
 
         match self.name.as_str() {
             "OUT_0" => iio_thread_stm32

--- a/src/digital_io/gpio/test.rs
+++ b/src/digital_io/gpio/test.rs
@@ -57,14 +57,6 @@ impl BitOr for LineRequestFlags {
     }
 }
 
-pub struct ChipDecoy;
-
-impl ChipDecoy {
-    pub fn label(&self) -> &'static str {
-        "test"
-    }
-}
-
 pub struct FindDecoy {
     name: String,
     val: Arc<AtomicU8>,
@@ -78,10 +70,6 @@ impl FindDecoy {
             name: self.name.clone(),
             val: self.val.clone(),
         })
-    }
-
-    pub fn chip(&self) -> ChipDecoy {
-        ChipDecoy
     }
 
     pub fn stub_get(&self) -> u8 {

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -631,7 +631,7 @@ mod tests {
 
         let (adc, dut_pwr, led) = {
             let mut bb = BrokerBuilder::new();
-            let adc = block_on(Adc::new(&mut bb, &mut wtb)).unwrap();
+            let adc = block_on(Adc::new(&mut bb, &mut wtb, hardware_generation)).unwrap();
             let led = Topic::anonymous(None);
 
             let dut_pwr = block_on(DutPwrThread::new(
@@ -792,7 +792,7 @@ mod tests {
 
         let (adc, dut_pwr) = {
             let mut bb = BrokerBuilder::new();
-            let adc = block_on(Adc::new(&mut bb, &mut wtb)).unwrap();
+            let adc = block_on(Adc::new(&mut bb, &mut wtb, hardware_generation)).unwrap();
             let led = Topic::anonymous(None);
 
             let dut_pwr = block_on(DutPwrThread::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use iobus::IoBus;
 use led::Led;
 use regulators::Regulators;
 use setup_mode::SetupMode;
-use system::System;
+use system::{HardwareGeneration, System};
 use temperatures::Temperatures;
 use ui::{message, setup_display, ScreenShooter, Ui, UiResources};
 use usb_hub::UsbHub;
@@ -67,6 +67,10 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
     // MQTT/REST APIs.
     // The topics are also used to pass around data inside the tacd.
     let mut bb = BrokerBuilder::new();
+
+    // We need to know which generation of LXA TAC we are running on at various
+    // places in the init process.
+    let hardware_generation = HardwareGeneration::get()?;
 
     // Expose hardware on the TAC via the broker framework.
     let backlight = Backlight::new(&mut bb, &mut wtb)?;
@@ -110,7 +114,7 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
 
     // Expose information about the system provided by the kernel via the
     // broker framework.
-    let system = System::new(&mut bb);
+    let system = System::new(&mut bb, hardware_generation);
 
     // Make sure the ADC and power switching threads of the tacd are not
     // stalled for too long by providing watchdog events to systemd

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
 
     // Expose information about the system provided by the kernel via the
     // broker framework.
-    let system = System::new(&mut bb, hardware_generation);
+    let system = System::new(&mut bb, hardware_generation)?;
 
     // Make sure the ADC and power switching threads of the tacd are not
     // stalled for too long by providing watchdog events to systemd

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
         adc.pwr_volt.clone(),
         adc.pwr_curr.clone(),
         led.dut_pwr.clone(),
+        hardware_generation,
     )
     .await?;
     let dig_io = DigitalIo::new(&mut bb, &mut wtb, led.out_0.clone(), led.out_1.clone())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
     // Expose hardware on the TAC via the broker framework.
     let backlight = Backlight::new(&mut bb, &mut wtb)?;
     let led = Led::new(&mut bb, &mut wtb)?;
-    let adc = Adc::new(&mut bb, &mut wtb).await?;
+    let adc = Adc::new(&mut bb, &mut wtb, hardware_generation).await?;
     let dut_pwr = DutPwrThread::new(
         &mut bb,
         &mut wtb,

--- a/src/regulators.rs
+++ b/src/regulators.rs
@@ -32,7 +32,7 @@ mod reg {
 
     pub fn regulator_set(name: &str, state: bool) -> Result<()> {
         if name == "output_iobus_12v" {
-            let iio_thread = block_on(IioThread::new_stm32(&())).unwrap();
+            let iio_thread = block_on(IioThread::new_stm32(&(), ())).unwrap();
 
             iio_thread
                 .clone()

--- a/src/system.rs
+++ b/src/system.rs
@@ -24,22 +24,28 @@ use crate::broker::{BrokerBuilder, Topic};
 #[cfg(feature = "demo_mode")]
 mod read_dt_props {
     const DEMO_DATA_STR: &[(&str, &str)] = &[
-        ("barebox-version", "barebox-2022.11.0-20221121-1"),
+        ("chosen/barebox-version", "barebox-2022.11.0-20221121-1"),
         (
-            "baseboard-factory-data/pcba-hardware-release",
+            "chosen/baseboard-factory-data/pcba-hardware-release",
             "lxatac-S01-R03-B02-C00",
         ),
         (
-            "powerboard-factory-data/pcba-hardware-release",
+            "chosen/powerboard-factory-data/pcba-hardware-release",
             "lxatac-S05-R03-V01-C00",
         ),
     ];
 
     const DEMO_DATA_NUM: &[(&str, u32)] = &[
-        ("baseboard-factory-data/modification", 0),
-        ("baseboard-factory-data/factory-timestamp", 1678086417),
-        ("powerboard-factory-data/modification", 0),
-        ("powerboard-factory-data/factory-timestamp", 1678086418),
+        ("chosen/baseboard-factory-data/modification", 0),
+        (
+            "chosen/baseboard-factory-data/factory-timestamp",
+            1678086417,
+        ),
+        ("chosen/powerboard-factory-data/modification", 0),
+        (
+            "chosen/powerboard-factory-data/factory-timestamp",
+            1678086418,
+        ),
     ];
 
     pub fn read_dt_property(path: &str) -> String {
@@ -58,10 +64,10 @@ mod read_dt_props {
     use std::fs::read;
     use std::str::from_utf8;
 
-    const DT_CHOSEN: &str = "/sys/firmware/devicetree/base/chosen/";
+    const DT_BASE: &str = "/sys/firmware/devicetree/base/";
 
     pub fn read_dt_property(path: &str) -> String {
-        let bytes = read([DT_CHOSEN, path].join("/")).unwrap();
+        let bytes = read([DT_BASE, path].join("/")).unwrap();
         from_utf8(bytes.strip_suffix(&[0]).unwrap())
             .unwrap()
             .to_string()
@@ -110,24 +116,26 @@ impl Barebox {
     fn get() -> Self {
         // Get info from devicetree chosen
         Self {
-            version: read_dt_property("barebox-version"),
+            version: read_dt_property("chosen/barebox-version"),
             baseboard_release: {
-                let template = read_dt_property("baseboard-factory-data/pcba-hardware-release");
-                let changeset = read_dt_property_u32("baseboard-factory-data/modification");
+                let template =
+                    read_dt_property("chosen/baseboard-factory-data/pcba-hardware-release");
+                let changeset = read_dt_property_u32("chosen/baseboard-factory-data/modification");
 
                 template.replace("-C??", &format!("-C{changeset:02}"))
             },
             powerboard_release: {
-                let template = read_dt_property("powerboard-factory-data/pcba-hardware-release");
-                let changeset = read_dt_property_u32("powerboard-factory-data/modification");
+                let template =
+                    read_dt_property("chosen/powerboard-factory-data/pcba-hardware-release");
+                let changeset = read_dt_property_u32("chosen/powerboard-factory-data/modification");
 
                 template.replace("-C??", &format!("-C{changeset:02}"))
             },
             baseboard_timestamp: {
-                read_dt_property_u32("baseboard-factory-data/factory-timestamp")
+                read_dt_property_u32("chosen/baseboard-factory-data/factory-timestamp")
             },
             powerboard_timestamp: {
-                read_dt_property_u32("powerboard-factory-data/factory-timestamp")
+                read_dt_property_u32("chosen/powerboard-factory-data/factory-timestamp")
             },
         }
     }

--- a/src/usb_hub.rs
+++ b/src/usb_hub.rs
@@ -94,7 +94,7 @@ mod rw {
 
         for (path_tail, iio_channel) in DISABLE_CHANNELS {
             if path.ends_with(path_tail) {
-                let iio_thread = block_on(IioThread::new_stm32(&())).unwrap();
+                let iio_thread = block_on(IioThread::new_stm32(&(), ())).unwrap();
 
                 iio_thread
                     .get_channel(iio_channel)

--- a/web/src/DashboardTac.tsx
+++ b/web/src/DashboardTac.tsx
@@ -137,6 +137,24 @@ export default function DashboardTac() {
               }}
             />
           </Box>
+          <Box>
+            <Box variant="awsui-key-label">Hardware Generation</Box>
+            <MqttBox
+              topic="/v1/tac/info/hardware_generation"
+              format={(msg: string) => {
+                switch (msg) {
+                  case "Gen1":
+                    return "Generation 1";
+                  case "Gen2":
+                    return "Generation 2";
+                  case "Gen3":
+                    return "Generation 3";
+                  default:
+                    return msg;
+                }
+              }}
+            />
+          </Box>
         </ColumnLayout>
 
         <Form


### PR DESCRIPTION
This is an alternative to #64, which reads the LXA TAC hardware generation explicitly and sets up the correct ADC channels based on the hardware generation, not based on which channels are available.

This difference is based on a comment in https://github.com/linux-automation/tacd/pull/64#issuecomment-2017537666 , which suggest checking the hardware generation explicitly.

Since both approaches are valid I've decided to open a new PR instead of pushing over the previous one.

Since it would be inconsistent to check the generation explicitly in one location but implicitly in another, this PR also replaces the existing Gen 1 / Gen 2 differentiation in `src/dut_power.rs`.

TODO before merging:

- [x] Test on actual generation 3 hardware
