### PR TITLE
ci: update the GitHub actions used where appropriate

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -20,7 +20,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -42,7 +42,7 @@ jobs:
     name: cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1
@@ -68,7 +68,7 @@ jobs:
     name: cargo check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1
@@ -85,14 +85,14 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   test:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -28,7 +28,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: latest
       - run: npx prettier@=3.3.3 --check .
@@ -41,7 +41,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: latest
       - name: npx license-checker
@@ -57,7 +57,7 @@ jobs:
         working-directory: web
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: latest
       - run: npm ci

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -27,7 +27,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: latest
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: latest
@@ -56,7 +56,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: latest


### PR DESCRIPTION
There are some GitHub actions we use that have newer versions available.
Update them.

Sadly I've noticed that the [actions-rs](https://github.com/actions-rs/) actions we use are currently unmaintained and archived.
Currently they are not broken, so there is no rush to move to an alternatice, but that may be the case in the future.