### PR TITLE
rauc: use InstallBundle and InspectBundle instead of deprecated DBus methods

### DIFF
--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -55,8 +55,8 @@ mod imports {
         }
 
         pub async fn info(&self, _url: &str) -> anyhow::Result<(String, String)> {
-            let compatible = "LXA TAC".to_string();
-            let version = "4.0-0-20230428214619".to_string();
+            let compatible = "Linux Automation GmbH - LXA TAC".to_string();
+            let version = "24.04-20240415070800".to_string();
 
             Ok((compatible, version))
         }

--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -45,6 +45,8 @@ use installer::InstallerProxy;
 
 #[cfg(feature = "demo_mode")]
 mod imports {
+    use std::collections::HashMap;
+
     pub(super) struct InstallerProxy<'a> {
         _dummy: &'a (),
     }
@@ -54,11 +56,24 @@ mod imports {
             Some(Self { _dummy: &() })
         }
 
-        pub async fn info(&self, _url: &str) -> anyhow::Result<(String, String)> {
-            let compatible = "Linux Automation GmbH - LXA TAC".to_string();
-            let version = "24.04-20240415070800".to_string();
+        pub async fn inspect_bundle(
+            &self,
+            _source: &str,
+            _args: HashMap<&str, zbus::zvariant::Value<'_>>,
+        ) -> zbus::Result<HashMap<String, zbus::zvariant::OwnedValue>> {
+            let update: HashMap<String, String> = [
+                (
+                    "compatible".into(),
+                    "Linux Automation GmbH - LXA TAC".into(),
+                ),
+                ("version".into(), "24.04-20240415070800".into()),
+            ]
+            .into();
 
-            Ok((compatible, version))
+            let info: HashMap<String, zbus::zvariant::OwnedValue> =
+                [("update".into(), update.into())].into();
+
+            Ok(info)
         }
     }
 

--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -532,7 +532,9 @@ impl Rauc {
                 // Poor-mans validation. It feels wrong to let someone point to any
                 // file on the TAC from the web interface.
                 if url.starts_with("http://") || url.starts_with("https://") {
-                    if let Err(e) = proxy.install(&url).await {
+                    let args = HashMap::new();
+
+                    if let Err(e) = proxy.install_bundle(&url, args).await {
                         error!("Failed to install bundle: {}", e);
                     }
                 }


### PR DESCRIPTION
This makes it so we no longer use deprecated RAUC DBus APIs.

The `Install` -> `InstallBundle` migration is straight forward.

The `Info` -> `InspectBundle` migration is a bit trickier, since RAUC provides the results as nested dictionaries (and also arrays nested inside of that, but we do not currently need any info from those).
This requires a fair bit of type conversions at runtime and the use of some rather funky generics from the `zvariants` crate.
There are probably more elegant solutions to implement the `tacd`-side of this, but for now `zvariant_walk_nested_dicts` gives us something that works.