### PR TITLE
rauc/systemd: allow struct fields being unread in demo_mode

### DIFF
--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -102,6 +102,7 @@ pub struct Rauc {
     pub operation: Arc<Topic<String>>,
     pub progress: Arc<Topic<Progress>>,
     pub slot_status: Arc<Topic<Arc<SlotStatus>>>,
+    #[cfg_attr(feature = "demo_mode", allow(dead_code))]
     pub primary: Arc<Topic<String>>,
     pub last_error: Arc<Topic<String>>,
     pub install: Arc<Topic<String>>,

--- a/src/dbus/systemd.rs
+++ b/src/dbus/systemd.rs
@@ -52,6 +52,7 @@ pub enum ServiceAction {
 
 #[derive(Clone)]
 pub struct Service {
+    #[cfg_attr(feature = "demo_mode", allow(dead_code))]
     pub action: Arc<Topic<ServiceAction>>,
     pub status: Arc<Topic<ServiceStatus>>,
 }


### PR DESCRIPTION
This fixes new `cargo clippy` errors that complain about unused fields when the `demo_mode` feature is enabled:

```
$ cargo clippy --features=demo_mode --no-default-features
   --> src/dbus/rauc.rs:105:9
    |
101 | pub struct Rauc {
    |            ---- field in this struct
...
105 |     pub primary: Arc<Topic<String>>,
    |         ^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(dead_code)]`


error: field `action` is never read
  --> src/dbus/systemd.rs:55:9
   |
54 | pub struct Service {
   |            ------- field in this struct
55 |     pub action: Arc<Topic<ServiceAction>>,
   |         ^^^^^^
   |
   = note: `Service` has a derived impl for the trait `Clone`, …