### PR TITLE
ui: screens: diagnostics: add screen with bringup-relevant information

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1050,6 +1050,14 @@ components:
           type: string
         powerboard_timestamp:
           type: string
+        baseboard_featureset:
+          type: array
+          items:
+            type: string
+        powerboard_featureset:
+          type: array
+          items:
+            type: string
 
     IOBusServerInfo:
       type: object

--- a/src/system.rs
+++ b/src/system.rs
@@ -42,6 +42,14 @@ mod read_dt_props {
             "chosen/powerboard-factory-data/pcba-hardware-release",
             "lxatac-S05-R03-V01-C00",
         ),
+        (
+            "chosen/baseboard-factory-data/featureset",
+            "base,tft,calibrated",
+        ),
+        (
+            "chosen/powerboard-factory-data/featureset",
+            "base,calibrated",
+        ),
     ];
 
     const DEMO_DATA_NUM: &[(&str, u32)] = &[
@@ -145,6 +153,8 @@ pub struct Barebox {
     pub powerboard_release: String,
     pub baseboard_timestamp: u32,
     pub powerboard_timestamp: u32,
+    pub baseboard_featureset: Vec<String>,
+    pub powerboard_featureset: Vec<String>,
 }
 
 impl Barebox {
@@ -171,6 +181,18 @@ impl Barebox {
             },
             powerboard_timestamp: {
                 read_dt_property_u32("chosen/powerboard-factory-data/factory-timestamp")?
+            },
+            baseboard_featureset: {
+                read_dt_property("chosen/baseboard-factory-data/featureset")?
+                    .split(',')
+                    .map(str::to_string)
+                    .collect()
+            },
+            powerboard_featureset: {
+                read_dt_property("chosen/powerboard-factory-data/featureset")?
+                    .split(',')
+                    .map(str::to_string)
+                    .collect()
             },
         })
     }

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -27,6 +27,7 @@ use embedded_graphics::{
 };
 use serde::{Deserialize, Serialize};
 
+mod diagnostics;
 mod dig_out;
 mod help;
 mod iobus;
@@ -45,6 +46,7 @@ mod update_installation;
 mod usb;
 mod usb_overload;
 
+use diagnostics::DiagnosticsScreen;
 use dig_out::DigOutScreen;
 use help::HelpScreen;
 use iobus::IoBusScreen;
@@ -93,6 +95,7 @@ pub enum AlertScreen {
     UsbOverload,
     Help,
     Setup,
+    Diagnostics,
     OverTemperature,
 }
 
@@ -198,6 +201,7 @@ pub(super) fn init(
         Box::new(SystemScreen::new()),
         Box::new(UartScreen::new()),
         Box::new(UsbScreen::new()),
+        Box::new(DiagnosticsScreen::new()),
         Box::new(HelpScreen::new(wtb, alerts, &res.setup_mode.show_help)?),
         Box::new(IoBusHealthScreen::new(
             wtb,

--- a/src/ui/screens/diagnostics.rs
+++ b/src/ui/screens/diagnostics.rs
@@ -1,0 +1,112 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2024 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use std::fmt::Write;
+
+use async_std::sync::Arc;
+use async_trait::async_trait;
+use embedded_graphics::{
+    mono_font::{ascii::FONT_6X10, MonoTextStyle},
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+use super::{
+    ActivatableScreen, ActiveScreen, AlertList, AlertScreen, Alerter, Display, InputEvent, Screen,
+    Ui,
+};
+use crate::broker::Topic;
+
+const SCREEN_TYPE: AlertScreen = AlertScreen::Diagnostics;
+
+pub struct DiagnosticsScreen;
+
+struct Active {
+    display: Option<Display>,
+    alerts: Arc<Topic<AlertList>>,
+}
+
+fn diagnostic_text() -> Result<String, std::fmt::Error> {
+    let mut text = String::new();
+
+    writeln!(&mut text, "Diagnostics | Not self-updating!")?;
+    writeln!(&mut text, "Short press lower button to toggle LEDs.")?;
+    writeln!(&mut text, "Long press lower button to exit.")?;
+    writeln!(&mut text)?;
+
+    Ok(text)
+}
+
+impl DiagnosticsScreen {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ActivatableScreen for DiagnosticsScreen {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    fn activate(&mut self, ui: &Ui, display: Display) -> Box<dyn ActiveScreen> {
+        let ui_text_style: MonoTextStyle<BinaryColor> =
+            MonoTextStyle::new(&FONT_6X10, BinaryColor::On);
+
+        let text = diagnostic_text().unwrap_or_else(|_| "Failed to format text".into());
+
+        display.with_lock(|target| {
+            Rectangle::with_corners(Point::new(0, 0), Point::new(239, 239))
+                .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+                .draw(target)
+                .unwrap();
+
+            Text::with_baseline(&text, Point::new(4, 2), ui_text_style, Baseline::Top)
+                .draw(target)
+                .unwrap();
+        });
+
+        let active = Active {
+            display: Some(display),
+            alerts: ui.alerts.clone(),
+        };
+
+        Box::new(active)
+    }
+}
+
+#[async_trait]
+impl ActiveScreen for Active {
+    fn my_type(&self) -> Screen {
+        Screen::Alert(SCREEN_TYPE)
+    }
+
+    async fn deactivate(mut self: Box<Self>) -> Display {
+        self.display.take().unwrap()
+    }
+
+    fn input(&mut self, ev: InputEvent) {
+        match ev {
+            InputEvent::NextScreen => {}
+            InputEvent::ToggleAction(_) => {}
+            InputEvent::PerformAction(_) => {
+                self.alerts.deassert(SCREEN_TYPE);
+            }
+        }
+    }
+}

--- a/src/ui/screens/diagnostics.rs
+++ b/src/ui/screens/diagnostics.rs
@@ -74,6 +74,32 @@ fn diagnostic_text(ui: &Ui) -> Result<String, std::fmt::Error> {
     }
 
     writeln!(&mut text)?;
+
+    if let Some(bridge_interface) = ui.res.network.bridge_interface.try_get() {
+        write!(&mut text, "br: ")?;
+
+        for ip in bridge_interface {
+            write!(&mut text, "{ip}, ")?;
+        }
+
+        writeln!(&mut text)?;
+    }
+
+    let interfaces = [
+        ("dut", &ui.res.network.dut_interface),
+        ("uplink", &ui.res.network.uplink_interface),
+    ];
+
+    for (name, interface) in interfaces {
+        if let Some(link) = interface.try_get() {
+            let speed = link.speed;
+            let carrier = if link.carrier { "up" } else { "down" };
+
+            write!(&mut text, "{name}: {speed} {carrier} | ")?;
+        }
+    }
+
+    writeln!(&mut text)?;
     writeln!(&mut text)?;
 
     if let Some(barebox) = ui.res.system.barebox.try_get() {


### PR DESCRIPTION
When bringup up a new LXA TAC we want to see a few things right away:

  - Is the screen straight inside the housing.
  - Are all versions (hardware and software) as expected.
  - Are the ADC channels calibrated.
  - Is the correct update channel activated.

This is easily done with a diagnostics screen. The screen is available via a special button sequence from the setup mode screen.

- Why the setup mode screen?

    After bringing up a new TAC the setup mode will be active and should
    stay active until the devices arrives at the customer.
    This means the diagnostics mode should be reachable via the setup mode
    screen.

- Why a special button sequence?

    The customer may try to skip the setup process using the buttons on
    the device (which is intentionally not possible).
    Why means they are likely to make quite a few random inputs.
    These should not activate the diagnostics mode as to not spook the user.

The screen looks something like this (the white border is used to align the screen):

<img src="https://github.com/linux-automation/tacd/assets/1273320/b963ff1d-d506-4009-9b25-27235eab9d02" width="480" height="480" style="image-rendering: pixelated; image-rendering: crisp-edges;">

_(The image may appear blurry due to scaling applied by your browser)_