### PR TITLE
ci: codespell: add spell checking CI job

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git/*,./web/build/*,./web/node_modules/*,./web/package-lock.json,./target/*
+ignore-words-list = crate,ser

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -1,0 +1,16 @@
+name: codespell
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  codespell:
+    name: codespell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 -m pip install codespell
+      - run: codespell

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Make sure cargo commands not only fail on hard errors but also on warnings
-  # so we do not accidentially miss newly introduced warnings.
+  # so we do not accidentally miss newly introduced warnings.
   RUSTFLAGS: -D warnings
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Next you will have to build an SDK using `meta-lxatac`that includes `libiio`:
 
 And install it on your host PC.
 
-To build using the SDK you will have to `souce` it according to the yocto SDK
+To build using the SDK you will have to `source` it according to the yocto SDK
 documentation and add the following to the `.cargo/config.toml`:
 
     [target.armv7-unknown-linux-gnueabihf]

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,5 @@
 # I've removed most of the lines from the template config generated via
-# cargo deny init to keep this readble.
+# cargo deny init to keep this readable.
 # If you want to change something it may be worthwhile to run cargo deny init
 # to get an overview of the options and their defaults.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,7 +26,7 @@ paths:
               $ref: '#/components/schemas/Screen'
       responses:
         '204':
-          description: The screen was set sucessfully
+          description: The screen was set successfully
         '400':
           description: The value could not be parsed into a screen name
 
@@ -61,7 +61,7 @@ paths:
               type: number
       responses:
         '204':
-          description: The display brightness was set sucessfully
+          description: The display brightness was set successfully
         '400':
           description: The value could not be parsed as a number
 
@@ -109,7 +109,7 @@ paths:
               type: boolean
       responses:
         '204':
-          description: The locator status was set sucessfully
+          description: The locator status was set successfully
         '400':
           description: The value could not be parsed into a boolean
 

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -272,7 +272,7 @@ impl IioThread {
         // like setting the priority or some iio setup, as not all structs
         // are Send.
         // We do however not want to return from new() before we know that the
-        // setup was sucessful.
+        // setup was successful.
         // This is why we create Self inside the thread and send it back
         // to the calling thread via a queue.
         let (thread_tx, thread_rx) = bounded(1);

--- a/src/broker/persistence.rs
+++ b/src/broker/persistence.rs
@@ -56,7 +56,7 @@ fn load(topics: &[Arc<dyn AnyTopic>]) -> Result<()> {
     let file: PersistenceFile = from_reader(File::open(path)?)?;
 
     if file.format_version != 1 {
-        bail!("Unkown state file version: {}", file.format_version);
+        bail!("Unknown state file version: {}", file.format_version);
     }
 
     let mut content = file.persistent_topics;

--- a/src/dbus/rauc.rs
+++ b/src/dbus/rauc.rs
@@ -410,7 +410,7 @@ impl Rauc {
                     primary.set_if_changed(p);
                 }
 
-                // Referesh the slot status whenever the current operation changes
+                // Refresh the slot status whenever the current operation changes
                 // This is mostly relevant for "installing" -> "idle" transitions
                 // but it can't hurt to do it on any transition.
                 if let Ok(slots) = proxy.get_slot_status().await {
@@ -420,7 +420,7 @@ impl Rauc {
                             let mut info: HashMap<String, String> = slot_info
                                 .into_iter()
                                 .map(|(k, v)| {
-                                    // Convert itegers to strings as raw zvariant values are
+                                    // Convert integers to strings as raw zvariant values are
                                     // unusable when json serialized and I can not be bothered
                                     // to fiddle around with an enum that wraps strings and integers
                                     // or something like that

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -333,7 +333,7 @@ impl DutPwrThread {
         let pwr_line = pwr_line.request(flags, 1 - PWR_LINE_ASSERTED, "tacd")?;
         let discharge_line = discharge_line.request(flags, DISCHARGE_LINE_ASSERTED, "tacd")?;
 
-        // The realtime priority must be set up inside the tread, but
+        // The realtime priority must be set up inside the thread, but
         // the operation may fail, in which case we want new() to fail
         // as well.
         // Use a queue to notify the calling thread if the priority setup

--- a/src/http_server/serve_dir.rs
+++ b/src/http_server/serve_dir.rs
@@ -103,8 +103,8 @@ async fn file(req: &Request<()>, fs_path: &Path) -> Result {
         })
         .unwrap_or(false);
 
-    // Make sure the client re-validates quite regularily if its cached
-    // ressource is still up to date (every 30s).
+    // Make sure the client re-validates quite regularly if its cached
+    // resource is still up to date (every 30s).
     let res_builder = Response::builder(200)
         .header("Last-Modified", last_modified)
         .header("Cache-Control", "max-age=30, must-revalidate");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -257,7 +257,7 @@ impl Ui {
                             // The NextScreen event for normal screens can be handled
                             // here.
                             // The situation for alerts is a bit more complicated.
-                            // (Some ignore all input. Some acknoledge via the upper button).
+                            // (Some ignore all input. Some acknowledge via the upper button).
                             // Leave handling for NextScreen to them.
 
                             match (st, ev) {

--- a/src/ui/screens/power.rs
+++ b/src/ui/screens/power.rs
@@ -126,7 +126,7 @@ impl ActivatableScreen for PowerScreen {
                 Box::new(|state: &OutputState| match state {
                     OutputState::On => IndicatorState::On,
                     OutputState::Off | OutputState::OffFloating => IndicatorState::Off,
-                    OutputState::Changing => IndicatorState::Unkown,
+                    OutputState::Changing => IndicatorState::Unknown,
                     _ => IndicatorState::Error,
                 }),
             )

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -40,7 +40,7 @@ pub enum IndicatorState {
     On,
     Off,
     Error,
-    Unkown,
+    Unknown,
 }
 
 pub struct WidgetContainer {
@@ -301,7 +301,7 @@ impl<T: Serialize + DeserializeOwned + Send + Sync + Clone + 'static> DynamicWid
 
                         Some(text.bounding_box())
                     }
-                    IndicatorState::Unkown => {
+                    IndicatorState::Unknown => {
                         let text = Text::with_alignment(
                             "?",
                             anchor + Point::new(4, 10),


### PR DESCRIPTION
This PR fixes spelling mistakes found by the `codespell` util and adds a CI job to make sure we do not add new typos in the future.