### PR TITLE
ci: also run jobs on a schedule

### DIFF
--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '48 20 * * 4'
 
 jobs:
   codespell:

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '48 20 * * 4'
 
 env:
   # Make sure cargo commands not only fail on hard errors but also on warnings

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '48 20 * * 4'
 
 env:
   # Generating sourcemaps fails with file not found in the autolinker


### PR DESCRIPTION
We have been bitten before by upstream `codespell` or `cargo clippy` adding new checks in times of low activity on the repo, resulting in the next pull requests to fail.

Make sure we notice such changes early by running the jobs on a schedule every then and now.
The scheduled time of 20:48 UTC every thursday was chosen by fair dice roll.

TODO before merging:

- [x] This PR is based on #72, which adds the `codespell` CI job, which this PR changes to also run it on a schedule. That PR should be merged first.