### PR TITLE
cargo deny: acknowledge lexical-core < 1 (a tide dependency) as unsound

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ ignore = [
    "RUSTSEC-2021-0060",
    "RUSTSEC-2021-0064",
    "RUSTSEC-2023-0065",
+   "RUSTSEC-2023-0086",
 ]
 
 [bans]


### PR DESCRIPTION
Since tide did not have a new release since 2021 there is not too much that we can do about this other than move away from tide.

But that is a larger undertaking. Until then I have read through the [advisory][1] and think we should be fine for the time being.

[1]: https://rustsec.org/advisories/RUSTSEC-2023-0086

This should make our [scheduled CI builds](https://github.com/linux-automation/tacd/actions/workflows/tacd-daemon.yaml) succeed again, which would be great.