### PR TITLE
ci: tacd: remove dependencies on actions-rs GitHub actions

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -62,7 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - run: rustup toolchain install stable
+      - run: cargo install --locked cargo-deny
+      - run: cargo deny check
 
   test:
     name: cargo test

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -22,10 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     strategy:
@@ -62,9 +59,7 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - run: rustup toolchain install ${{ matrix.version }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: rustup run ${{ matrix.version }} cargo check
 
   deny:
     name: cargo deny
@@ -81,6 +76,4 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - run: rustup toolchain install stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -38,11 +38,7 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
       - run: rustup toolchain install stable
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: ${{ matrix.features }}
-          name: Clippy Output
+      - run: cargo clippy ${{ matrix.features }}
 
   check:
     strategy:

--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -21,12 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt
-          override: true
+      - run: rustup toolchain install stable
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
@@ -45,12 +40,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: Swatinem/rust-cache@v2
+      - run: rustup toolchain install stable
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,12 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.version }}
-          override: true
-      - uses: Swatinem/rust-cache@v2
+      - run: rustup toolchain install ${{ matrix.version }}
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -95,12 +80,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install libsystemd-dev libiio-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v2
+      - run: rustup toolchain install stable
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
The [actions-rs](https://github.com/actions-rs/toolchain) project is no longer maintained and our workflow runs have produced a lot of warnings due to that for some time now.

Remove our dependency on it by calling `rustup` and `cargo` ourselves. This also makes the CI scripts easier to read in my opinion and easier to reproduce locally since you can just run the same commands as the CI does.