### PR TITLE
ci: tacd-webui: use a fixed node version instead of latest

### DIFF
--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -50,6 +50,12 @@ jobs:
           "0BSD;Apache-2.0;BSD-2-Clause;BSD-3-Clause;CC-BY-4.0;CC0-1.0;EPL-1.0;ISC;MIT;MPL-2.0;Python-2.0;Unlicense;WTFPL"
 
   build:
+    strategy:
+      fail-fast: false # Run against all versions even if one fails
+      matrix:
+        version:
+          - "20.12.2" # Yocto scarthgap
+          - "20.17.0" # Yocto styhead
     name: npm run build
     runs-on: ubuntu-latest
     defaults:
@@ -59,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: ${{ matrix.version }}
       - run: npm ci
       - run: npm run build
 

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 20.17.0
       - run: npx prettier@=3.3.3 --check .
 
   license:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 20.17.0
       - name: npx license-checker
         run: >
           npx license-checker --summary --excludePrivatePackages --onlyAllow
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 20.17.0
       - run: npm ci
       - run: npm run build
 
@@ -73,6 +73,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 20.17.0
       - run: npm ci
       - run: npm run test


### PR DESCRIPTION
The build sometimes breaks due to node updates. This would not be much of a problem if the fixes for these breakages did
not break our actual builds with the node versions used in Yocto.

Fix that by using a fixed node version - in this case the one from the Styhead release.

Also make sure the build works on Scarthgap as well.

This should fix the build issue we have seen in this scheduled run: https://github.com/linux-automation/tacd/actions/runs/11845302859