### PR TITLE
Fix warnings introduced in cargo clippy 1.84.0

### DIFF
--- a/src/dbus/rauc/update_channels.rs
+++ b/src/dbus/rauc/update_channels.rs
@@ -224,14 +224,14 @@ impl UpstreamBundle {
     pub(super) fn update_install(&mut self, slot_status: &SlotStatus) {
         let slot_0_is_older = slot_status
             .get("rootfs_0")
-            .filter(|r| r.get("boot_status").map_or(false, |b| b == "good"))
+            .filter(|r| r.get("boot_status").is_some_and(|b| b == "good"))
             .and_then(|r| r.get("bundle_version"))
             .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
             .unwrap_or(true);
 
         let slot_1_is_older = slot_status
             .get("rootfs_1")
-            .filter(|r| r.get("boot_status").map_or(false, |b| b == "good"))
+            .filter(|r| r.get("boot_status").is_some_and(|b| b == "good"))
             .and_then(|r| r.get("bundle_version"))
             .and_then(|v| compare_versions(&self.version, v).map(|c| c.is_gt()))
             .unwrap_or(true);

--- a/src/dbus/systemd.rs
+++ b/src/dbus/systemd.rs
@@ -80,7 +80,7 @@ impl ServiceStatus {
     }
 
     #[cfg(not(feature = "demo_mode"))]
-    async fn get<'a>(unit: &service::UnitProxy<'a>) -> Result<Self> {
+    async fn get(unit: &service::UnitProxy<'_>) -> Result<Self> {
         Ok(Self {
             active_state: unit.active_state().await?,
             sub_state: unit.sub_state().await?,

--- a/src/motd.rs
+++ b/src/motd.rs
@@ -211,7 +211,7 @@ pub fn run(
                         .filter_map(|ch| {
                             ch.bundle
                             .as_ref()
-                            .map_or(false, |b| b.newer_than_installed)
+                            .is_some_and(|b| b.newer_than_installed)
                             .then_some(ch.url)
                         })
                         .collect();


### PR DESCRIPTION
The `cargo clippy` command has learned new tricks in version 1.84.0 that was released yesterday, causing our [CI to fail](https://github.com/linux-automation/tacd/actions/runs/12698305028).

Fix those so our CI jobs are nice and green again.