### PR TITLE
dbus: typo fix

### DIFF
--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -68,7 +68,7 @@ pub use rauc::Rauc;
 pub use tacd::Tacd;
 
 /// Bunch together everything that uses a DBus system connection here, even
-/// though it is conceptionally independent
+/// though it is conceptually independent
 pub struct DbusSession {
     pub hostname: Hostname,
     pub network: Network,


### PR DESCRIPTION
It [looks like](https://github.com/linux-automation/tacd/actions/runs/12937874780/job/36086772633) `codespell` has once again learned a word that it can spell better than me.

Good bot. Have a cookie: 🍪.