### PR TITLE
broker: use correct indentation in list in comment

### DIFF
--- a/src/broker.rs
+++ b/src/broker.rs
@@ -53,16 +53,16 @@ impl BrokerBuilder {
     /// * `web_readable` - Should this resource be externally readable?
     /// * `web_writable` - Should this resource be externally writable?
     /// * `initial` - Retained value to return before set() was called the
-    ///    first time. Or None
+    ///   first time. Or None
     /// * `retained_length` - Number of previously set values to retain
-    ///    and push out when subscribing to the serialized stream.
-    ///    This will usually be 1 so that the most recent value is available
-    ///    when doing a GET request to the topic via the REST API.
-    ///    It can also be 0 for topics that are purely transient events like
-    ///    button presses that go away as soon as they happen.
-    ///    It can also be a larger value to store up some history that should
-    ///    be pushed out to new (outside) subscribers as soon as they subscribe,
-    ///    to e.g. pre-populate a graph in the web interface.
+    ///   and push out when subscribing to the serialized stream.
+    ///   This will usually be 1 so that the most recent value is available
+    ///   when doing a GET request to the topic via the REST API.
+    ///   It can also be 0 for topics that are purely transient events like
+    ///   button presses that go away as soon as they happen.
+    ///   It can also be a larger value to store up some history that should
+    ///   be pushed out to new (outside) subscribers as soon as they subscribe,
+    ///   to e.g. pre-populate a graph in the web interface.
     pub fn topic<E: Serialize + DeserializeOwned + Sync + Send + Clone + 'static>(
         &mut self,
         path: &str,


### PR DESCRIPTION
This fixes a linter error that was added to cargo clippy in release 1.86.0:

    clippy::doc-overindented-list-items