### PR TITLE
update `tokio` and `url` dependencies to fix cargo deny errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2970,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "pin-project-lite 0.2.15",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,9 +3103,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",


### PR DESCRIPTION
Recent `cargo-deny` job runs have [failed](https://github.com/linux-automation/tacd/actions/runs/14390041898/job/40354751625) due to an Advisory in `tokio` and a yanked version of `url` in our `Cargo.lock`.
Fix both issues by updating the respective dependencies.