### PR TITLE
ci: tacd,tacd-webui: Update node and rust versions to those in yocto walnascar

### DIFF
--- a/.github/workflows/tacd-daemon.yaml
+++ b/.github/workflows/tacd-daemon.yaml
@@ -45,8 +45,7 @@ jobs:
       fail-fast: false # Run against all versions even if one fails
       matrix:
         version:
-          - "1.75" # Yocto scarthgap
-          - "1.79" # Yocto styhead
+          - "1.84" # Yocto walnascar
           - "nightly"
     name: cargo check
     runs-on: ubuntu-latest

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 22.15.0
       - run: npx prettier@=3.3.3 --check .
 
   license:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 22.15.0
       - name: npx license-checker
         run: >
           npx license-checker --summary --excludePrivatePackages --onlyAllow
@@ -79,6 +79,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.17.0
+          node-version: 22.15.0
       - run: npm ci
       - run: npm run test

--- a/.github/workflows/tacd-webui.yaml
+++ b/.github/workflows/tacd-webui.yaml
@@ -54,8 +54,7 @@ jobs:
       fail-fast: false # Run against all versions even if one fails
       matrix:
         version:
-          - "20.12.2" # Yocto scarthgap
-          - "20.17.0" # Yocto styhead
+          - "22.14.0" # Yocto walnascar
     name: npm run build
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
We have updated meta-lxatac to the yocto walnascar release.

Since we do not have to go back this is the only version we have to check explicitly now.