### PR TITLE
Cargo clippy deny 2025 05 23

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ ignore = [
    "RUSTSEC-2021-0064",
    "RUSTSEC-2023-0086",
    "RUSTSEC-2024-0384",
+   "RUSTSEC-2025-0036",
 ]
 
 [bans]

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -28,8 +28,8 @@ use tide::{Request, Response, Server};
 #[cfg(any(test, feature = "demo_mode"))]
 mod sd {
     use std::collections::btree_map::BTreeMap;
+    use std::io::Error;
     pub(super) use std::io::Result;
-    use std::io::{Error, ErrorKind};
     use std::thread::sleep;
     use std::time::{Duration, SystemTime};
 
@@ -81,7 +81,7 @@ mod sd {
                 sleep(Duration::from_secs(5));
             }
 
-            Err(Error::new(ErrorKind::Other, "Simulation ended"))
+            Err(Error::other("Simulation ended"))
         }
     }
 }


### PR DESCRIPTION
We had CI [build failures](https://github.com/linux-automation/tacd/actions/runs/15196560469/job/42741975004) today because `cargo deny` and `cargo clippy` have learned new tricks.

Acknowledge that `async-std` and crates based on it are deprecated and apply a change suggested by `cargo clippy`.