### PR TITLE
ui: display: prevent mismatched_lifetime_syntaxes compile warning

### DIFF
--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -144,7 +144,7 @@ impl DisplayExclusive {
     ///
     /// Drawing a pixel to the bottom of DisplayRotated results in the pixel
     /// appearing on the right of the actual screen.
-    pub fn rotate(&mut self) -> DisplayRotated {
+    pub fn rotate(&mut self) -> DisplayRotated<'_> {
         // This could easily be made more generic, by accepting a direction
         // parameter, but that would result in dead code because we only
         // draw the button legend rotated.


### PR DESCRIPTION
The missing lifetime annotation results in the build showing a warning when compiled using the nightly toolchain:



    error: lifetime flowing from input to output with different syntax can be confusing
       --> src/ui/display.rs:147:19
         |
     147 |     pub fn rotate(&mut self) -> DisplayRotated {
         |                   ^^^^^^^^^     -------------- the lifetime gets resolved as `'_`
         |                   |
         |                   this lifetime flows to the output
         |
         = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
         = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
     help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
         |
     147 |     pub fn rotate(&mut self) -> DisplayRotated<'_> {
         |                                               ++++

Fix that by adding the suggested annotation.

Since we have configured warnings to result in build errors in our CI this results in [failed jobs](https://github.com/linux-automation/tacd/actions/runs/15620550073/job/44004056864).