### PR TITLE
tacd: use variable names inside format! strings where possible

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -96,7 +96,7 @@ fn generate_build_date() {
         .unwrap()
         .as_secs();
 
-    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", timestamp);
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={timestamp}");
 }
 
 fn main() {

--- a/src/led/extras.rs
+++ b/src/led/extras.rs
@@ -142,7 +142,7 @@ impl Pattern for Leds {
                     let brightness = (brightness * max).round();
                     let duration = duration.as_millis();
 
-                    write!(dst, "{} {} ", brightness, duration)
+                    write!(dst, "{brightness} {duration} ")
                         .expect("Writing to a String should never fail");
 
                     dst

--- a/src/ui/screens/diagnostics.rs
+++ b/src/ui/screens/diagnostics.rs
@@ -55,7 +55,7 @@ fn diagnostic_text(ui: &Ui) -> Result<String, std::fmt::Error> {
     writeln!(&mut text)?;
 
     if let Some(tacd_version) = ui.res.system.tacd_version.try_get() {
-        writeln!(&mut text, "v: {}", tacd_version)?;
+        writeln!(&mut text, "v: {tacd_version}")?;
     }
 
     if let Some(uname) = ui.res.system.uname.try_get() {
@@ -69,7 +69,7 @@ fn diagnostic_text(ui: &Ui) -> Result<String, std::fmt::Error> {
             HardwareGeneration::Gen3 => "Gen3",
         };
 
-        write!(&mut text, "generation: {} ", gen)?;
+        write!(&mut text, "generation: {gen} ")?;
     }
 
     if let Some(soc_temperature) = ui.res.temperatures.soc_temperature.try_get() {
@@ -116,12 +116,12 @@ fn diagnostic_text(ui: &Ui) -> Result<String, std::fmt::Error> {
         let powerboard_featureset = barebox.powerboard_featureset.join(",");
 
         writeln!(&mut text, "barebox: {}", barebox.version)?;
-        writeln!(&mut text, "baseboard ({}):", baseboard_release)?;
-        writeln!(&mut text, "- bringup: {}", baseboard_timestamp)?;
-        writeln!(&mut text, "- feat: {}", baseboard_featureset)?;
-        writeln!(&mut text, "powerboard ({}):", powerboard_release)?;
-        writeln!(&mut text, "- bringup: {}", powerboard_timestamp)?;
-        writeln!(&mut text, "- feat: {}", powerboard_featureset)?;
+        writeln!(&mut text, "baseboard ({baseboard_release}):")?;
+        writeln!(&mut text, "- bringup: {baseboard_timestamp}")?;
+        writeln!(&mut text, "- feat: {baseboard_featureset}")?;
+        writeln!(&mut text, "powerboard ({powerboard_release}):")?;
+        writeln!(&mut text, "- bringup: {powerboard_timestamp}")?;
+        writeln!(&mut text, "- feat: {powerboard_featureset}")?;
     }
 
     writeln!(&mut text)?;

--- a/src/ui/screens/system.rs
+++ b/src/ui/screens/system.rs
@@ -120,7 +120,7 @@ impl ActivatableScreen for SystemScreen {
                 row_anchor(3),
                 Box::new(|ips: &Vec<String>| {
                     let ip = ips.first().map(|s| s.as_str()).unwrap_or("-");
-                    format!("IP:  {}", ip)
+                    format!("IP:  {ip}")
                 }),
             )
         });


### PR DESCRIPTION
This was prompted by the newly introduced [`uninlined_format_args`][1] clippy lint.

This should fix the CI errors seen in [this job](https://github.com/linux-automation/tacd/actions/runs/15912233459/job/44882187329).

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args