### PR TITLE
ui: buttons: fix clippy warning about confusing lifetimes

### DIFF
--- a/src/ui/buttons.rs
+++ b/src/ui/buttons.rs
@@ -38,7 +38,7 @@ mod evd {
             Ok(Self {})
         }
 
-        pub fn fetch_events(&mut self) -> Result<FetchEventsSynced, ()> {
+        pub fn fetch_events(&mut self) -> Result<FetchEventsSynced<'_>, ()> {
             loop {
                 std::thread::park()
             }


### PR DESCRIPTION
This feels like something where clippy suggested the exact opposite in the past, but I am not in the mood to argue.

Fixes the following warnings:

     error: hiding a lifetime that's elided elsewhere is confusing
      --> src/ui/buttons.rs:41:29
       |
    41 |         pub fn fetch_events(&mut self) -> Result<FetchEventsSynced, ()> {
       |                             ^^^^^^^^^            ----------------- the same lifetime is hidden here
       |                             |
       |                             the lifetime is elided here
       |
       = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
       = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
       = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
    help: use `'_` for type paths
       |
    41 |         pub fn fetch_events(&mut self) -> Result<FetchEventsSynced<'_>, ()> {
       |                                                                   ++++