### PR TITLE
cargo deny: acknowledge that "async-std" is discontinued

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ ignore = [
    "RUSTSEC-2023-0086",
    "RUSTSEC-2024-0384",
    "RUSTSEC-2025-0036",
+   "RUSTSEC-2025-0052",
 ]
 
 [bans]


### PR DESCRIPTION
This confirms what we have known for some time now: async-std is no more and we have to migrate away from it.

This silences the error message that makes the [scheduled runs](https://github.com/linux-automation/tacd/actions/runs/17307596003) fail.