### PR TITLE
tacd: replace instances of x % N == 0 with x.is_multiple_of(N)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,3 @@ lto = true
 overflow-checks = true
 opt-level = "z"
 codegen-units = 1
-
-[lints.clippy]
-# This is necessary because the `.is_multiple_of()` function that this lint
-# suggests is not yet stabilized in the rust version used in Yocto walnascar
-# (1.84.1).
-# TODO: remove this when updating to a newer yocto release.
-manual_is_multiple_of = "allow"

--- a/src/dut_power.rs
+++ b/src/dut_power.rs
@@ -245,7 +245,7 @@ impl<const N: usize> MedianFilter<N> {
                 sorted
             };
 
-            if N % 2 == 0 {
+            if N.is_multiple_of(2) {
                 Some((sorted[N / 2 - 1] + sorted[N / 2]) / 2.0)
             } else {
                 Some(sorted[N / 2])

--- a/src/ui/screens/diagnostics.rs
+++ b/src/ui/screens/diagnostics.rs
@@ -253,7 +253,7 @@ impl ActiveScreen for Active {
             InputEvent::ToggleAction(_) => {
                 self.led_cycle_state = self.led_cycle_state.wrapping_add(1);
 
-                let on = self.led_cycle_state % 2 != 0;
+                let on = !self.led_cycle_state.is_multiple_of(2);
                 let led_brightness = if on { 1.0 } else { 0.0 };
                 let backlight_brightness = if on { 1.0 } else { 0.1 };
                 let status_color = match self.led_cycle_state % 8 {

--- a/src/ui/screens/locator.rs
+++ b/src/ui/screens/locator.rs
@@ -120,7 +120,7 @@ impl ActivatableScreen for LocatorScreen {
                 display,
                 Box::new(move |now, target| {
                     // Blink a bar below the hostname at 2Hz
-                    let on = (now.duration_since(start).as_millis() / 500) % 2 == 0;
+                    let on = (now.duration_since(start).as_millis() / 500).is_multiple_of(2);
 
                     if on {
                         let line = Line::new(Point::new(40, 135), Point::new(200, 135))


### PR DESCRIPTION
This is inspired by a recently added clippy lint:

     error: manual implementation of `.is_multiple_of()`
       --> src/dut_power.rs:248:16
        |
    248 |             if N % 2 == 0 {
        |                ^^^^^^^^^^ help: replace with: `N.is_multiple_of(2)`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
        = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
        = help: to override `-D warnings` add `#[allow(clippy::manual_is_multiple_of)]`

    error: manual implementation of `.is_multiple_of()`
       --> src/ui/screens/diagnostics.rs:256:26
        |
    256 |                 let on = self.led_cycle_state % 2 != 0;
        |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!self.led_cycle_state.is_multiple_of(2)`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of

This should fix the [currently broken scheduled builds](https://github.com/linux-automation/tacd/actions/runs/17841050557/job/50730345729).