### PR TITLE
tacd: disable clippy lint that we can not currently fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,10 @@ lto = true
 overflow-checks = true
 opt-level = "z"
 codegen-units = 1
+
+[lints.clippy]
+# This is necessary because the `.is_multiple_of()` function that this lint
+# suggests is not yet stabilized in the rust version used in Yocto walnascar
+# (1.84.1).
+# TODO: remove this when updating to a newer yocto release.
+manual_is_multiple_of = "allow"


### PR DESCRIPTION
Clippy suggests using [`.is_multiple_of()`](https://doc.rust-lang.org/std/primitive.u8.html#method.is_multiple_of) on numbers, which has however only been stabilized quite recently with rustc version 1.87.0 (2025-05-15), too young for our current Yocto release, which ships rustc 1.84 (2025-01-09).

Disable the lint until we update our rustc version.

This replaces PR #101 for now, which does the change suggested by clippy.