### PR TITLE
web: show link to the manual under "Documentation" in the sidebar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -100,11 +100,17 @@ function Navigation() {
             items: [
               { type: "link", text: "REST API", href: "#/docs/api" },
               { type: "link", text: "Legal Information", href: "#/docs/legal" },
+              {
+                type: "link",
+                external: true,
+                text: "LXA TAC Manual",
+                href: "https://www.linux-automation.com/lxatac-M02/index.html",
+              },
             ],
           },
           {
             type: "section",
-            text: "External Links",
+            text: "Other Services",
             items: [
               {
                 type: "link",
@@ -117,12 +123,6 @@ function Navigation() {
                 external: true,
                 text: "LXA IOBus Server",
                 href: `http://${window.location.hostname}:8080/`,
-              },
-              {
-                type: "link",
-                external: true,
-                text: "LXA TAC Manual",
-                href: "https://www.linux-automation.com/lxatac-M02/index.html",
               },
             ],
           },


### PR DESCRIPTION
... instead of the "External Links" section.

The icon should make it clear enough that this is an external link and this should make the manual a bit easier to find.

Since all remaining external links now refer to other services on the TAC also rename the section accordingly.

Before:

<img width="280" height="726" alt="before" src="https://github.com/user-attachments/assets/f3e5abab-bd1c-4fd2-8020-1059230596b4" />

After:

<img width="280" height="746" alt="after" src="https://github.com/user-attachments/assets/9ed348cb-76ca-4516-b638-1f6458195e80" />

Thanks to @michaelolbrich for suggesting the change.