### PR TITLE
Add tools to test LXATAC features and speedup bringup.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ yaml_serde = "0.10"
 zbus = "5.13"
 zvariant_derive = "5.9"
 zvariant = { version = "5.9", default-features = false, features = ["enumflags2"] }
+clap = { version = "4.6.0", features = ["derive"] }
+
 
 [features]
 default = ["systemd"]

--- a/src/adc/iio/demo_mode.rs
+++ b/src/adc/iio/demo_mode.rs
@@ -99,10 +99,15 @@ impl CalibratedChannel {
         channels: [&Self; N],
     ) -> Result<[Measurement; N]> {
         let ts = Timestamp::now();
-        let mut results = [Measurement { ts, value: 0.0 }; N];
+        let mut results = [Measurement {
+            ts,
+            value: 0.0,
+            raw: None,
+        }; N];
 
         for i in 0..N {
-            results[i].value = channels[i].get().unwrap().value;
+            results[i] = channels[i].get().unwrap();
+            results[i].ts = ts;
         }
 
         Ok(results)
@@ -146,7 +151,9 @@ impl CalibratedChannel {
 
         self.inner.value.store(value.to_bits(), Ordering::Relaxed);
 
-        Ok(Measurement { ts, value })
+        let raw = Some((value * 1024.0) as i32);
+
+        Ok(Measurement { ts, value, raw })
     }
 
     pub fn set(&self, state: bool) {

--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -158,8 +158,13 @@ impl CalibratedChannel {
                 .ok_or(AdcReadError::TimeStampError)?;
             let ts = Timestamp::new(ts);
 
-            let mut values = [Measurement { ts, value: 0.0 }; N];
+            let mut values = [Measurement {
+                ts,
+                value: 0.0,
+                raw: None,
+            }; N];
             for i in 0..N {
+                values[i].raw = Some(values_raw[i] as i32);
                 values[i].value = channels[i].calibration.apply(values_raw[i] as f32);
             }
 

--- a/src/adc/iio/test.rs
+++ b/src/adc/iio/test.rs
@@ -63,7 +63,11 @@ impl CalibratedChannel {
             *ts -= Duration::from_millis(500)
         }
 
-        let mut results = [Measurement { ts, value: 0.0 }; N];
+        let mut results = [Measurement {
+            ts,
+            value: 0.0,
+            raw: None,
+        }; N];
 
         for i in 0..N {
             // If a transient is scheduled (channels[i].transient != NO_TRANSIENT)

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,0 +1,205 @@
+// This file is part of tacd, the LXA TAC system daemon
+// Copyright (C) 2022 Pengutronix e.K.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this library; if not, see <https://www.gnu.org/licenses/>.
+
+use anyhow::Result;
+use async_std::future::pending;
+use log::{error, info};
+
+use crate::adc::Adc;
+use crate::backlight::Backlight;
+use crate::broker::BrokerBuilder;
+use crate::dbus::DbusSession;
+use crate::digital_io::DigitalIo;
+use crate::dut_power::DutPwrThread;
+use crate::http_server::HttpServer;
+use crate::iobus::IoBus;
+use crate::led::Led;
+use crate::regulators::Regulators;
+use crate::setup_mode::SetupMode;
+use crate::system::{HardwareGeneration, System};
+use crate::temperatures::Temperatures;
+use crate::ui::{ScreenShooter, Ui, UiResources, message, setup_display};
+use crate::usb_hub::UsbHub;
+use crate::watchdog::Watchdog;
+use crate::watched_tasks::WatchedTasksBuilder;
+
+async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)> {
+    // The tacd spawns a couple of async tasks that should run as long as
+    // the tacd runs and if any one fails the tacd should stop.
+    // These tasks are spawned via the watched task builder.
+    let mut wtb = WatchedTasksBuilder::new();
+
+    // The BrokerBuilder collects topics that should be exported via the
+    // MQTT/REST APIs.
+    // The topics are also used to pass around data inside the tacd.
+    let mut bb = BrokerBuilder::new();
+
+    // We need to know which generation of LXA TAC we are running on at various
+    // places in the init process.
+    let hardware_generation = HardwareGeneration::get()?;
+
+    // Expose hardware on the TAC via the broker framework.
+    let backlight = Backlight::new(&mut bb, &mut wtb)?;
+    let led = Led::new(&mut bb, &mut wtb)?;
+    let adc = Adc::new(&mut bb, &mut wtb, hardware_generation).await?;
+    let dut_pwr = DutPwrThread::new(
+        &mut bb,
+        &mut wtb,
+        adc.pwr_volt.clone(),
+        adc.pwr_curr.clone(),
+        led.dut_pwr.clone(),
+        hardware_generation,
+    )
+    .await?;
+    let dig_io = DigitalIo::new(&mut bb, &mut wtb, led.out_0.clone(), led.out_1.clone())?;
+    let regulators = Regulators::new(&mut bb, &mut wtb)?;
+    let temperatures = Temperatures::new(&mut bb, &mut wtb)?;
+    let usb_hub = UsbHub::new(
+        &mut bb,
+        &mut wtb,
+        adc.usb_host_curr.fast.clone(),
+        adc.usb_host1_curr.fast.clone(),
+        adc.usb_host2_curr.fast.clone(),
+        adc.usb_host3_curr.fast.clone(),
+    )?;
+
+    // Expose other software on the TAC via the broker framework by connecting
+    // to them via HTTP / DBus APIs.
+    let iobus = IoBus::new(
+        &mut bb,
+        &mut wtb,
+        regulators.iobus_pwr_en.clone(),
+        adc.iobus_curr.fast.clone(),
+        adc.iobus_volt.fast.clone(),
+    )?;
+    let (hostname, network, rauc, systemd) = {
+        let dbus =
+            DbusSession::new(&mut bb, &mut wtb, led.eth_dut.clone(), led.eth_lab.clone()).await?;
+
+        (dbus.hostname, dbus.network, dbus.rauc, dbus.systemd)
+    };
+
+    // Expose information about the system provided by the kernel via the
+    // broker framework.
+    let system = System::new(&mut bb, hardware_generation)?;
+
+    // Make sure the ADC and power switching threads of the tacd are not
+    // stalled for too long by providing watchdog events to systemd
+    // (if requested on start).
+    let watchdog = Watchdog::new(dut_pwr.tick());
+
+    // Set up a http server and provide some static files like the web
+    // interface and config files that may be edited inside the web ui.
+    let mut http_server = HttpServer::new();
+
+    // Allow editing some aspects of the TAC configuration when in "setup mode".
+    let setup_mode = SetupMode::new(&mut bb, &mut wtb, &mut http_server.server)?;
+
+    // Expose a live log of the TAC's systemd journal so it can be viewed
+    // in the web interface.
+    crate::journal::serve(&mut http_server.server);
+
+    // Maintain a /etc/motd with useful information about the TAC.
+    if let Err(err) = crate::motd::run(
+        &mut wtb,
+        &dut_pwr,
+        &iobus,
+        &rauc,
+        &setup_mode,
+        &temperatures,
+        &usb_hub,
+    ) {
+        error!("failed to start motd update service with {err}");
+    }
+
+    // Set up the user interface for the hardware display on the TAC.
+    // The different screens receive updates via the topics provided in
+    // the UiResources struct.
+    let ui = {
+        let resources = UiResources {
+            adc,
+            backlight,
+            dig_io,
+            dut_pwr,
+            hostname,
+            iobus,
+            led,
+            network,
+            rauc,
+            regulators,
+            setup_mode,
+            system,
+            systemd,
+            temperatures,
+            usb_hub,
+        };
+
+        Ui::new(&mut bb, &mut wtb, resources)?
+    };
+
+    // Consume the BrokerBuilder (no further topics can be added or removed)
+    // and expose the topics via HTTP and MQTT-over-websocket.
+    bb.build(&mut wtb, &mut http_server.server)?;
+
+    // Expose the display as a .png on the web server
+    crate::ui::serve_display(&mut http_server.server, screenshooter);
+
+    // Start serving files and the API
+    http_server.serve(&mut wtb)?;
+
+    // If a watchdog was requested by systemd we can now start feeding it
+    if let Some(watchdog) = watchdog {
+        watchdog.keep_fed(&mut wtb)?;
+    }
+
+    Ok((ui, wtb))
+}
+
+pub async fn daemon() -> Result<()> {
+    // Show a splash screen very early on
+    let display = setup_display();
+
+    // This allows us to expose screenshoots of the LCD screen via HTTP
+    let screenshooter = display.screenshooter();
+
+    match init(screenshooter).await {
+        Ok((ui, mut wtb)) => {
+            // Start drawing the UI
+            ui.run(&mut wtb, display)?;
+
+            info!("Setup complete. Handling requests");
+
+            wtb.watch().await
+        }
+        Err(e) => {
+            // Display a detailed error message on stderr (and thus in the journal) ...
+            error!("Failed to initialize tacd: {e}");
+
+            // ... and a generic message on the LCD, as it can not fit a lot of detail.
+            display.clear();
+            display.with_lock(|target| {
+                message(
+                    target,
+                    "tacd failed to start!\n\nCheck log for info.\nWaiting for watchdog\nto restart tacd.",
+                );
+            });
+
+            // Wait forever (or more likely until the systemd watchdog timer hits)
+            // to give the user a chance to actually see the error message.
+            pending().await
+        }
+    }
+}

--- a/src/led.rs
+++ b/src/led.rs
@@ -30,13 +30,13 @@ mod demo_mode;
 mod extras;
 
 #[cfg(feature = "demo_mode")]
-use demo_mode::{Brightness, Leds, SysClass};
+pub use demo_mode::{Brightness, Leds, SysClass};
 
 #[cfg(not(feature = "demo_mode"))]
-use sysfs_class::{Brightness, Leds, SysClass};
+pub use sysfs_class::{Brightness, Leds, SysClass};
 
 pub use extras::{BlinkPattern, BlinkPatternBuilder};
-use extras::{Pattern, RgbColor};
+pub use extras::{Pattern, RgbColor};
 
 pub struct Led {
     pub out_0: Arc<Topic<BlinkPattern>>,
@@ -53,7 +53,7 @@ pub struct Led {
 /// Different versions of the hardware have different amounts of on-board LEDs,
 /// so not finding an LED should not be a critical error.
 /// Just show a not and go on if an LED can not be set up.
-fn get_led_checked(hardware_name: &'static str) -> Option<Leds> {
+pub fn get_led_checked(hardware_name: &'static str) -> Option<Leds> {
     match Leds::new(hardware_name) {
         Ok(led) => Some(led),
         Err(err) if err.kind() == ErrorKind::NotFound => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,12 @@
 // with this library; if not, see <https://www.gnu.org/licenses/>.
 
 use anyhow::Result;
-use async_std::future::pending;
 use clap::{self, Parser};
-use log::{error, info};
 
 mod adc;
 mod backlight;
 mod broker;
+mod daemon;
 mod dbus;
 mod digital_io;
 mod dut_power;
@@ -40,24 +39,6 @@ mod ui;
 mod usb_hub;
 mod watchdog;
 mod watched_tasks;
-
-use adc::Adc;
-use backlight::Backlight;
-use broker::BrokerBuilder;
-use dbus::DbusSession;
-use digital_io::DigitalIo;
-use dut_power::DutPwrThread;
-use http_server::HttpServer;
-use iobus::IoBus;
-use led::Led;
-use regulators::Regulators;
-use setup_mode::SetupMode;
-use system::{HardwareGeneration, System};
-use temperatures::Temperatures;
-use ui::{ScreenShooter, Ui, UiResources, message, setup_display};
-use usb_hub::UsbHub;
-use watchdog::Watchdog;
-use watched_tasks::WatchedTasksBuilder;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "tacd")]
@@ -79,181 +60,13 @@ enum CliCommands {
     },
 }
 
-async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)> {
-    // The tacd spawns a couple of async tasks that should run as long as
-    // the tacd runs and if any one fails the tacd should stop.
-    // These tasks are spawned via the watched task builder.
-    let mut wtb = WatchedTasksBuilder::new();
-
-    // The BrokerBuilder collects topics that should be exported via the
-    // MQTT/REST APIs.
-    // The topics are also used to pass around data inside the tacd.
-    let mut bb = BrokerBuilder::new();
-
-    // We need to know which generation of LXA TAC we are running on at various
-    // places in the init process.
-    let hardware_generation = HardwareGeneration::get()?;
-
-    // Expose hardware on the TAC via the broker framework.
-    let backlight = Backlight::new(&mut bb, &mut wtb)?;
-    let led = Led::new(&mut bb, &mut wtb)?;
-    let adc = Adc::new(&mut bb, &mut wtb, hardware_generation).await?;
-    let dut_pwr = DutPwrThread::new(
-        &mut bb,
-        &mut wtb,
-        adc.pwr_volt.clone(),
-        adc.pwr_curr.clone(),
-        led.dut_pwr.clone(),
-        hardware_generation,
-    )
-    .await?;
-    let dig_io = DigitalIo::new(&mut bb, &mut wtb, led.out_0.clone(), led.out_1.clone())?;
-    let regulators = Regulators::new(&mut bb, &mut wtb)?;
-    let temperatures = Temperatures::new(&mut bb, &mut wtb)?;
-    let usb_hub = UsbHub::new(
-        &mut bb,
-        &mut wtb,
-        adc.usb_host_curr.fast.clone(),
-        adc.usb_host1_curr.fast.clone(),
-        adc.usb_host2_curr.fast.clone(),
-        adc.usb_host3_curr.fast.clone(),
-    )?;
-
-    // Expose other software on the TAC via the broker framework by connecting
-    // to them via HTTP / DBus APIs.
-    let iobus = IoBus::new(
-        &mut bb,
-        &mut wtb,
-        regulators.iobus_pwr_en.clone(),
-        adc.iobus_curr.fast.clone(),
-        adc.iobus_volt.fast.clone(),
-    )?;
-    let (hostname, network, rauc, systemd) = {
-        let dbus =
-            DbusSession::new(&mut bb, &mut wtb, led.eth_dut.clone(), led.eth_lab.clone()).await?;
-
-        (dbus.hostname, dbus.network, dbus.rauc, dbus.systemd)
-    };
-
-    // Expose information about the system provided by the kernel via the
-    // broker framework.
-    let system = System::new(&mut bb, hardware_generation)?;
-
-    // Make sure the ADC and power switching threads of the tacd are not
-    // stalled for too long by providing watchdog events to systemd
-    // (if requested on start).
-    let watchdog = Watchdog::new(dut_pwr.tick());
-
-    // Set up a http server and provide some static files like the web
-    // interface and config files that may be edited inside the web ui.
-    let mut http_server = HttpServer::new();
-
-    // Allow editing some aspects of the TAC configuration when in "setup mode".
-    let setup_mode = SetupMode::new(&mut bb, &mut wtb, &mut http_server.server)?;
-
-    // Expose a live log of the TAC's systemd journal so it can be viewed
-    // in the web interface.
-    journal::serve(&mut http_server.server);
-
-    // Maintain a /etc/motd with useful information about the TAC.
-    if let Err(err) = motd::run(
-        &mut wtb,
-        &dut_pwr,
-        &iobus,
-        &rauc,
-        &setup_mode,
-        &temperatures,
-        &usb_hub,
-    ) {
-        error!("failed to start motd update service with {err}");
-    }
-
-    // Set up the user interface for the hardware display on the TAC.
-    // The different screens receive updates via the topics provided in
-    // the UiResources struct.
-    let ui = {
-        let resources = UiResources {
-            adc,
-            backlight,
-            dig_io,
-            dut_pwr,
-            hostname,
-            iobus,
-            led,
-            network,
-            rauc,
-            regulators,
-            setup_mode,
-            system,
-            systemd,
-            temperatures,
-            usb_hub,
-        };
-
-        Ui::new(&mut bb, &mut wtb, resources)?
-    };
-
-    // Consume the BrokerBuilder (no further topics can be added or removed)
-    // and expose the topics via HTTP and MQTT-over-websocket.
-    bb.build(&mut wtb, &mut http_server.server)?;
-
-    // Expose the display as a .png on the web server
-    ui::serve_display(&mut http_server.server, screenshooter);
-
-    // Start serving files and the API
-    http_server.serve(&mut wtb)?;
-
-    // If a watchdog was requested by systemd we can now start feeding it
-    if let Some(watchdog) = watchdog {
-        watchdog.keep_fed(&mut wtb)?;
-    }
-
-    Ok((ui, wtb))
-}
-
-async fn daemon() -> Result<()> {
-    // Show a splash screen very early on
-    let display = setup_display();
-
-    // This allows us to expose screenshoots of the LCD screen via HTTP
-    let screenshooter = display.screenshooter();
-
-    match init(screenshooter).await {
-        Ok((ui, mut wtb)) => {
-            // Start drawing the UI
-            ui.run(&mut wtb, display)?;
-
-            info!("Setup complete. Handling requests");
-
-            wtb.watch().await
-        }
-        Err(e) => {
-            // Display a detailed error message on stderr (and thus in the journal) ...
-            error!("Failed to initialize tacd: {e}");
-
-            // ... and a generic message on the LCD, as it can not fit a lot of detail.
-            display.clear();
-            display.with_lock(|target| {
-                message(
-                    target,
-                    "tacd failed to start!\n\nCheck log for info.\nWaiting for watchdog\nto restart tacd.",
-                );
-            });
-
-            // Wait forever (or more likely until the systemd watchdog timer hits)
-            // to give the user a chance to actually see the error message.
-            pending().await
-        }
-    }
-}
-
 #[async_std::main]
 async fn main() -> Result<()> {
     env_logger::init();
     let cli = Cli::parse();
 
     match cli.command.unwrap_or(CliCommands::Daemon) {
-        CliCommands::Daemon => daemon().await,
+        CliCommands::Daemon => daemon::daemon().await,
         CliCommands::Selftest { tests } => selftest::selftests(tests).await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 
 use anyhow::Result;
 use async_std::future::pending;
+use clap::{self, Parser};
 use log::{error, info};
 
 mod adc;
@@ -31,6 +32,7 @@ mod led;
 mod measurement;
 mod motd;
 mod regulators;
+mod selftest;
 mod setup_mode;
 mod system;
 mod temperatures;
@@ -56,6 +58,26 @@ use ui::{ScreenShooter, Ui, UiResources, message, setup_display};
 use usb_hub::UsbHub;
 use watchdog::Watchdog;
 use watched_tasks::WatchedTasksBuilder;
+
+#[derive(clap::Parser, Debug)]
+#[command(name = "tacd")]
+#[command(author, version, about)]
+#[command(propagate_version = true)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<CliCommands>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum CliCommands {
+    /// Start the tacd service
+    Daemon,
+    /// Helper to test LXATAC functions.
+    Selftest {
+        #[command(subcommand)]
+        tests: selftest::Commands,
+    },
+}
 
 async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)> {
     // The tacd spawns a couple of async tasks that should run as long as
@@ -189,10 +211,7 @@ async fn init(screenshooter: ScreenShooter) -> Result<(Ui, WatchedTasksBuilder)>
     Ok((ui, wtb))
 }
 
-#[async_std::main]
-async fn main() -> Result<()> {
-    env_logger::init();
-
+async fn daemon() -> Result<()> {
     // Show a splash screen very early on
     let display = setup_display();
 
@@ -225,5 +244,16 @@ async fn main() -> Result<()> {
             // to give the user a chance to actually see the error message.
             pending().await
         }
+    }
+}
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let cli = Cli::parse();
+
+    match cli.command.unwrap_or(CliCommands::Daemon) {
+        CliCommands::Daemon => daemon().await,
+        CliCommands::Selftest { tests } => selftest::selftests(tests).await,
     }
 }

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -26,13 +26,16 @@ pub struct Timestamp(Instant);
 pub struct Measurement {
     pub ts: Timestamp,
     pub value: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<i32>,
 }
 
 impl Measurement {
-    pub fn now(value: f32) -> Self {
+    pub fn now(value: f32, raw: Option<i32>) -> Self {
         Self {
             ts: Timestamp::now(),
             value,
+            raw,
         }
     }
 }

--- a/src/motd.rs
+++ b/src/motd.rs
@@ -24,10 +24,10 @@ use futures::FutureExt;
 use nix::errno::Errno;
 use nix::mount::MsFlags;
 
-use crate::WatchedTasksBuilder;
 use crate::dut_power::OutputState;
 use crate::temperatures::Warning;
 use crate::usb_hub::OverloadedPort;
+use crate::watched_tasks::WatchedTasksBuilder;
 
 #[cfg(feature = "demo_mode")]
 mod setup {

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -6,11 +6,13 @@ use crate::system::HardwareGeneration;
 use crate::watched_tasks::WatchedTasksBuilder;
 
 mod adc;
+mod ui;
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Sample ADC channels and calculate statistic
     Adc(adc::AdcArgs),
+    UiTest,
 }
 
 pub async fn selftests(command: Commands) -> Result<()> {
@@ -30,5 +32,6 @@ pub async fn selftests(command: Commands) -> Result<()> {
         Commands::Adc(adc_args) => {
             adc::collect_adc_samples(bb, wtb, hardware_generation, adc_args).await
         }
+        Commands::UiTest => ui::ui_test(bb, wtb).await,
     }
 }

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use clap::Subcommand;
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {}
+
+pub fn selftests(cli: Commands) -> Result<()> {
+    println!("{:?}", cli);
+    Ok(())
+}

--- a/src/selftest.rs
+++ b/src/selftest.rs
@@ -1,10 +1,34 @@
 use anyhow::Result;
 use clap::Subcommand;
 
-#[derive(Subcommand, Debug)]
-pub enum Commands {}
+use crate::broker::BrokerBuilder;
+use crate::system::HardwareGeneration;
+use crate::watched_tasks::WatchedTasksBuilder;
 
-pub fn selftests(cli: Commands) -> Result<()> {
-    println!("{:?}", cli);
-    Ok(())
+mod adc;
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Sample ADC channels and calculate statistic
+    Adc(adc::AdcArgs),
+}
+
+pub async fn selftests(command: Commands) -> Result<()> {
+    // The tacd spawns a couple of async tasks that should run as long as
+    // the tacd runs and if any one fails the tacd should stop.
+    // These tasks are spawned via the watched task builder.
+    let wtb = WatchedTasksBuilder::new();
+
+    // The BrokerBuilder collects topics that should be exported via the
+    // MQTT/REST APIs.
+    // The topics are also used to pass around data inside the tacd.
+    let bb = BrokerBuilder::new();
+
+    let hardware_generation = HardwareGeneration::get()?;
+
+    match command {
+        Commands::Adc(adc_args) => {
+            adc::collect_adc_samples(bb, wtb, hardware_generation, adc_args).await
+        }
+    }
 }

--- a/src/selftest/adc.rs
+++ b/src/selftest/adc.rs
@@ -1,0 +1,184 @@
+use std::time::Duration;
+
+use anyhow::{Error, Result};
+use async_std::task::sleep;
+use clap::{Args, ValueEnum};
+use serde::Serialize;
+
+use crate::adc::Adc;
+use crate::broker::BrokerBuilder;
+use crate::measurement::Measurement;
+use crate::system::HardwareGeneration;
+use crate::watched_tasks::WatchedTasksBuilder;
+
+#[derive(ValueEnum, Copy, Clone, Debug)]
+pub enum ADCChannels {
+    UsbHostCurr,
+    UsbHost1Curr,
+    UsbHost2Curr,
+    UsbHost3Curr,
+    Out0Volt,
+    Out1Volt,
+    IoBusVolt,
+    IoBusCurr,
+}
+
+#[derive(Args, Debug)]
+pub struct AdcArgs {
+    /// ADC channels to sample
+    #[arg(short, long, required = true)]
+    pub inputs: Vec<ADCChannels>,
+
+    /// Number of samples to collect
+    #[arg(short, long, default_value_t = 100)]
+    pub samples: u32,
+
+    /// Time between sample in ms
+    #[arg(short, long, default_value_t = 100)]
+    pub t_delta: u64,
+
+    /// Outputs every sample as they get collected.
+    #[arg(short, default_value_t = false)]
+    pub verbose: bool,
+
+    /// Add samples to output
+    #[arg(short, default_value_t = false)]
+    pub output_samples: bool,
+}
+
+/// The data we collect for an ADC channel
+struct AdcData {
+    channel_name: String,
+    samples: Vec<Measurement>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdcStatistic {
+    pub min: i32,
+    pub max: i32,
+    pub mean: i32,
+    pub std_dev: f32,
+    pub count: usize,
+    pub t_delta: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct AdcInfo<'a> {
+    channel_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    samples: Option<&'a Vec<Measurement>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    statistic: Option<AdcStatistic>,
+}
+
+impl AdcData {
+    fn statistics(&self, t_delta: u64) -> AdcStatistic {
+        let count = self.samples.len();
+        let sum: i32 = self.samples.iter().map(|x| x.raw.unwrap()).sum();
+        let mean = sum / count as i32;
+
+        let variance_sum = self
+            .samples
+            .iter()
+            .map(|x| (x.raw.unwrap() - mean).pow(2))
+            .sum::<i32>();
+
+        let variance = variance_sum as f32 / count as f32;
+
+        let std_dev = variance.sqrt();
+
+        let min = self.samples.iter().map(|x| x.raw.unwrap()).min().unwrap();
+        let max = self.samples.iter().map(|x| x.raw.unwrap()).max().unwrap();
+
+        AdcStatistic {
+            min,
+            max,
+            mean,
+            std_dev,
+            count,
+            t_delta,
+        }
+    }
+}
+
+pub async fn collect_adc_samples(
+    mut bb: BrokerBuilder,
+    mut wtb: WatchedTasksBuilder,
+    hardware_generation: HardwareGeneration,
+    args: AdcArgs,
+) -> Result<()> {
+    let adc = Adc::new(&mut bb, &mut wtb, hardware_generation).await?;
+
+    if args.verbose {
+        println!("ADC mode");
+        println!("  Samples: {}", args.samples);
+        println!("  Time delta: {}", args.t_delta);
+        println!("  Inputs: {:?}", args.inputs);
+    }
+
+    let num_samples = args.samples;
+
+    // Setup to collect ADC samples
+    let mut samples: Vec<AdcData> = Vec::new();
+    for adc_ch in args.inputs.iter() {
+        samples.push(AdcData {
+            channel_name: adc_ch.to_possible_value().unwrap().get_name().to_string(),
+            samples: Vec::new(),
+        });
+    }
+
+    let mut start = None;
+
+    // Collect samples from all selected channels interleaved
+    for _i in 0..num_samples {
+        for (i, adc_ch) in args.inputs.iter().enumerate() {
+            let adc_fn = match adc_ch {
+                ADCChannels::UsbHostCurr => &adc.usb_host_curr.fast,
+                ADCChannels::UsbHost1Curr => &adc.usb_host1_curr.fast,
+                ADCChannels::UsbHost2Curr => &adc.usb_host2_curr.fast,
+                ADCChannels::UsbHost3Curr => &adc.usb_host3_curr.fast,
+                ADCChannels::Out0Volt => &adc.out0_volt.fast,
+                ADCChannels::Out1Volt => &adc.out1_volt.fast,
+                ADCChannels::IoBusVolt => &adc.iobus_volt.fast,
+                ADCChannels::IoBusCurr => &adc.iobus_curr.fast,
+            };
+            let meas = adc_fn.get().map_err(|_| Error::msg("Adc Error"))?;
+
+            if args.verbose {
+                let ts = meas.ts.as_instant();
+                let ms_since_start = ts.duration_since(*start.get_or_insert(ts)).as_millis();
+
+                println!(
+                    "  {:15} | {:10}ms | {:15}A | {:10}",
+                    adc_ch.to_possible_value().unwrap().get_name(),
+                    ms_since_start,
+                    meas.value,
+                    meas.raw.unwrap_or(0)
+                );
+            }
+            samples[i].samples.push(meas);
+        }
+        sleep(Duration::from_millis(args.t_delta)).await;
+    }
+
+    // Build JSON output
+    let mut infos: Vec<AdcInfo> = Vec::new();
+    for i in samples.iter() {
+        let stat = i.statistics(args.t_delta);
+
+        let info = AdcInfo {
+            channel_name: i.channel_name.to_string(),
+            samples: if args.output_samples {
+                Some(&i.samples)
+            } else {
+                None
+            },
+            statistic: Some(stat),
+        };
+
+        infos.push(info);
+    }
+    let json = serde_json::to_string_pretty(&infos).unwrap();
+    println!("{}", json);
+    Ok(())
+}

--- a/src/selftest/ui.rs
+++ b/src/selftest/ui.rs
@@ -1,0 +1,150 @@
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use async_std::channel::Receiver;
+use async_std::stream::StreamExt;
+use futures::FutureExt;
+
+use crate::broker::Topic;
+use crate::led::{
+    BlinkPattern, BlinkPatternBuilder, Brightness, Pattern, RgbColor, get_led_checked,
+};
+use crate::ui::{Button, ButtonEvent, Direction, handle_buttons};
+use crate::{broker::BrokerBuilder, watched_tasks::WatchedTasksBuilder};
+
+const LIST_LEDS: [&str; 14] = [
+    "tac:green:statusdut",
+    "tac:green:dutpwr",
+    "tac:green:user1",
+    "tac:green:user2",
+    "tac:green:can",
+    "tac:green:iobus",
+    "tac:green:out0",
+    "tac:green:out1",
+    "tac:green:uarttx",
+    "tac:green:uartrx",
+    "tac:green:usbg",
+    "tac:green:usbh1",
+    "tac:green:usbh2",
+    "tac:green:usbh3",
+];
+
+fn set_all_leds() -> Result<()> {
+    println!("Setup LEDs");
+    let blink_pattern = BlinkPatternBuilder::new(1.0)
+        .stay_for(Duration::from_millis(500))
+        .step_to(0.0)
+        .stay_for(Duration::from_millis(500))
+        .forever();
+
+    for name in LIST_LEDS.iter() {
+        println!(" - {}", name);
+        let led = get_led_checked(name).ok_or(anyhow!("No LED with name {}", name))?;
+        led.set_pattern(blink_pattern.clone())?;
+    }
+    // Ethernet lab side
+    // This is a bi-color LED. So we need to swap polarity to see booth colors.
+    // /-----\_____/
+    // ___/-----\___
+    let led_o = get_led_checked("tac:orange:statuslab")
+        .ok_or(anyhow::anyhow!("No LED with name tac:orange:statuslab"))?;
+    let led_g = get_led_checked("tac:green:statuslab")
+        .ok_or(anyhow::anyhow!("No LED with name tac:green:statuslab"))?;
+    led_o.set_pattern(
+        BlinkPatternBuilder::new(1.0)
+            .stay_for(Duration::from_millis(1000))
+            .step_to(0.0)
+            .stay_for(Duration::from_millis(1000))
+            .forever(),
+    )?;
+    led_g.set_pattern(
+        BlinkPatternBuilder::new(0.0)
+            .stay_for(Duration::from_millis(500))
+            .step_to(1.0)
+            .stay_for(Duration::from_millis(1000))
+            .step_to(0.0)
+            .stay_for(Duration::from_millis(500))
+            .forever(),
+    )?;
+    Ok(())
+}
+
+fn clear_all_leds() -> Result<()> {
+    println!("Turn off LEDs");
+    let blink_pattern = BlinkPattern::solid(0.0);
+
+    for name in LIST_LEDS.iter() {
+        println!(" - {}", name);
+        let led = get_led_checked(name).ok_or(anyhow!("No LED with name {}", name))?;
+        led.set_pattern(blink_pattern.clone())?;
+    }
+    // Ethernet lab side
+    // Needed special setup so not in LIST_LEDS
+    let led_o = get_led_checked("tac:orange:statuslab")
+        .ok_or(anyhow::anyhow!("No LED with name tac:orange:statuslab"))?;
+    let led_g = get_led_checked("tac:green:statuslab")
+        .ok_or(anyhow::anyhow!("No LED with name tac:green:statuslab"))?;
+    led_o.set_pattern(blink_pattern.clone())?;
+    led_g.set_pattern(blink_pattern.clone())?;
+    Ok(())
+}
+
+fn set_rgb_led(red: bool, green: bool, blue: bool) -> Result<()> {
+    let led_rgb = get_led_checked("rgb:status").unwrap();
+    let max_brightness = led_rgb.max_brightness().unwrap();
+    led_rgb
+        .set_rgb_color(
+            max_brightness * (red as u64),
+            max_brightness * (green as u64),
+            max_brightness * (blue as u64),
+        )
+        .unwrap();
+    Ok(())
+}
+
+async fn wait_button_press(button_events: &mut Receiver<ButtonEvent>) -> Result<u8> {
+    while let Some(ev) = button_events.next().fuse().await {
+        println!("{:?}", ev);
+        match (ev.dir, ev.btn) {
+            (Direction::Press, Button::Lower) => return Ok(0b01),
+            (Direction::Press, Button::Upper) => return Ok(0b10),
+            _ => {}
+        }
+    }
+    anyhow::bail!("Button event queue ended unexpectedly")
+}
+
+pub async fn ui_test(mut _bb: BrokerBuilder, mut wtb: WatchedTasksBuilder) -> Result<()> {
+    let buttons = Topic::anonymous(None);
+    handle_buttons(
+        &mut wtb,
+        "/dev/input/by-path/platform-gpio-keys-event",
+        buttons.clone(),
+    )?;
+    let (mut button_events, _) = buttons.clone().subscribe_unbounded();
+
+    set_all_leds()?;
+    set_rgb_led(true, true, true)?;
+
+    let mut colors = [
+        (true, false, false),
+        (false, true, false),
+        (false, false, true),
+    ]
+    .into_iter()
+    .cycle();
+
+    let mut buttons_seen: u8 = 0;
+    loop {
+        buttons_seen |= wait_button_press(&mut button_events).await?;
+        if buttons_seen == 0b11 {
+            break;
+        }
+        let color = colors.next().unwrap();
+        set_rgb_led(color.0, color.1, color.2)?;
+    }
+
+    clear_all_leds()?;
+    set_rgb_led(false, false, false)?;
+    Ok(())
+}

--- a/src/temperatures.rs
+++ b/src/temperatures.rs
@@ -112,7 +112,7 @@ impl Temperatures {
                 let warning = Warning::from_temperatures(val);
                 warning_thread.set_if_changed(warning);
 
-                let meas = Measurement::now(val);
+                let meas = Measurement::now(val, None);
                 soc_temperature_thread.set(meas);
 
                 sleep(UPDATE_INTERVAL);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ mod screens;
 mod widgets;
 
 use alerts::{AlertList, Alerter};
-use buttons::{Button, ButtonEvent, Direction, PressDuration, Source, handle_buttons};
+pub use buttons::{Button, ButtonEvent, Direction, PressDuration, Source, handle_buttons};
 pub use display::{Display, ScreenShooter};
 pub use screens::message;
 use screens::{ActivatableScreen, AlertScreen, NormalScreen, Screen, splash};


### PR DESCRIPTION
To speedup bring up of the LXATAC this adds a second binary to collect ADC statistics and test LEDs, display and buttons.

To do this i needed to change the visibility of some structs/types/functions. And add color support.
The color support is probably still flaky as i am unsure how how to check for the color space used by the frame buffer.
It is also still missing color support the the Display view in the web ui.


The ADC part allows to collect ADC samples from multiple channels interleaved. This make measurements hopefully more correlated then the old way of collecting then separately.

The LED,Display ui test display a rainbow on the LCD and cycles the LEDs and LCD backlight when a button is pressed.
After both buttons have registered a press the ui-test will exit. (as this is only tested every ~5 press it might take some addition presses)