### PR TITLE
web: TacComponents: show "Every 10 Minutes" instead of "Every 600 Seconds

### DIFF
--- a/web/src/TacComponents.tsx
+++ b/web/src/TacComponents.tsx
@@ -392,7 +392,7 @@ export function UpdateChannels(props: UpdateChannelsProps) {
               return hours === 1 ? "Hourly" : `Every ${hours} Hours`;
             }
 
-            if (Math.floor(days) === days) {
+            if (Math.floor(minutes) === minutes) {
               return minutes === 1
                 ? "Once a minute"
                 : `Every ${minutes} Minutes`;


### PR DESCRIPTION
There was a copy and past error in the output handling. Fix that.