### PR TITLE
adc: iio: hardware: don't take unnecessary reference in debug! call

### DIFF
--- a/src/adc/iio/hardware.rs
+++ b/src/adc/iio/hardware.rs
@@ -210,7 +210,7 @@ impl IioThread {
 
         debug!("IIO devices:");
         for dev in ctx.devices() {
-            debug!("  * {}", &dev.name().unwrap_or_default());
+            debug!("  * {}", dev.name().unwrap_or_default());
         }
 
         let adc = ctx


### PR DESCRIPTION
Clippy has recently learned that taking a reference here is not required, failed the CI and now I know it as well.